### PR TITLE
Add CheckModel for dynamic DB table setup

### DIFF
--- a/hugashop/crm/Api/BaseModel.php
+++ b/hugashop/crm/Api/BaseModel.php
@@ -13,10 +13,10 @@ namespace HugaShop\Api;
 use HugaShop\Api\Config;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
-use Illuminate\Database\Eloquent\Model;
+use HugaShop\Api\CheckModel;
 use Illuminate\Database\Capsule\Manager as Capsule;
 
-abstract class BaseModel extends Model
+abstract class BaseModel extends CheckModel
 {
     protected static $IsAutoBooted = false;
 
@@ -100,8 +100,10 @@ abstract class BaseModel extends Model
      */
     public static function create(array|object $values): object
     {
-        $values = self::validateValues($values);
-        return static::query()->create($values);
+        return self::runWithInitTable(function () use ($values) {
+            $vals = self::validateValues($values);
+            return static::query()->create($vals);
+        });
     }
 
 
@@ -146,7 +148,9 @@ abstract class BaseModel extends Model
      */
     public static function deleteBy(string $field, $value): int
     {
-        return static::query()->where($field, $value)->delete();
+        return self::runWithInitTable(function () use ($field, $value) {
+            return static::query()->where($field, $value)->delete();
+        });
     }
 
 
@@ -155,8 +159,10 @@ abstract class BaseModel extends Model
      */
     public static function updateOne(int|array $ids, array|object $values)
     {
-        $values = self::validateValues($values);
-        return static::query()->whereId($ids)->update($values);
+        return self::runWithInitTable(function () use ($ids, $values) {
+            $vals = self::validateValues($values);
+            return static::query()->whereId($ids)->update($vals);
+        });
     }
 
 
@@ -165,7 +171,9 @@ abstract class BaseModel extends Model
      */
     public static function deleteOne(array|int $ids)
     {
-        return static::whereId($ids)->delete();
+        return self::runWithInitTable(function () use ($ids) {
+            return static::whereId($ids)->delete();
+        });
     }
 
 
@@ -215,10 +223,14 @@ abstract class BaseModel extends Model
 
         // Выбор полей
         if ($select) {
-            return $query->pluck($select)->toArray();
+            return self::runWithInitTable(function () use ($query, $select) {
+                return $query->pluck($select)->toArray();
+            });
         }
 
-        return $query->get();
+        return self::runWithInitTable(function () use ($query) {
+            return $query->get();
+        });
     }
 
 
@@ -246,7 +258,9 @@ abstract class BaseModel extends Model
             $query->where('id', $id);
         }
 
-        $result = $query->first();
+        $result = self::runWithInitTable(function () use ($query) {
+            return $query->first();
+        });
 
         // Settings
         if ($result) $result->settings = empty($result->settings) ? new \stdClass() : (object) unserialize($result->settings);
@@ -275,6 +289,8 @@ abstract class BaseModel extends Model
             }
         }
 
-        return $query->count();
+        return self::runWithInitTable(function () use ($query) {
+            return $query->count();
+        });
     }
 }

--- a/hugashop/crm/Api/CheckModel.php
+++ b/hugashop/crm/Api/CheckModel.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace HugaShop\Api;
+
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\QueryException;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Model with auto-check functionality for tables and columns.
+ */
+abstract class CheckModel extends Model
+{
+    protected static array $checkedTables = [];
+
+    /**
+     * Ensure that the database table and its fields exist
+     */
+    protected static function initTable(string $table)
+    {
+        if (isset(self::$checkedTables[$table]) || empty(static::$table_fields)) {
+            self::$checkedTables[$table] = true;
+            return;
+        }
+
+        $schema = Capsule::schema();
+
+        if (!$schema->hasTable($table)) {
+            $schema->create($table, function (Blueprint $blueprint) {
+                static::addColumns($blueprint, static::$table_fields);
+            });
+        } else {
+            foreach (static::$table_fields as $field => $options) {
+                if (!$schema->hasColumn($table, $field)) {
+                    $schema->table($table, function (Blueprint $blueprint) use ($field, $options) {
+                        static::addColumns($blueprint, [$field => $options]);
+                    });
+                }
+            }
+        }
+
+        self::$checkedTables[$table] = true;
+    }
+
+    /**
+     * Add columns to Blueprint instance
+     */
+    protected static function addColumns(Blueprint $blueprint, array $fields): void
+    {
+        foreach ($fields as $name => $params) {
+            $type    = $params['type'] ?? 'varchar';
+            $length  = $params['length'] ?? ($params['lenght'] ?? null);
+            $default = $params['def'] ?? null;
+            $extra   = $params['extra'] ?? null;
+
+            switch ($type) {
+                case 'int':
+                case 'created':
+                    if ($extra === 'AUTO_INCREMENT') {
+                        $column = $blueprint->increments($name);
+                    } else {
+                        $column = $blueprint->integer($name);
+                    }
+                    break;
+                case 'tinyint':
+                    $column = $blueprint->tinyInteger($name);
+                    break;
+                case 'char':
+                    $column = $blueprint->char($name, $length ?? 1);
+                    break;
+                case 'varchar':
+                    $column = $blueprint->string($name, $length ?? 255);
+                    break;
+                case 'text':
+                    $column = $blueprint->text($name);
+                    break;
+                case 'mediumtext':
+                    $column = $blueprint->mediumText($name);
+                    break;
+                case 'decimal':
+                    if ($length) {
+                        [$precision, $scale] = array_pad(explode('.', (string) $length), 2, 0);
+                        $column = $blueprint->decimal($name, (int) $precision, (int) $scale);
+                    } else {
+                        $column = $blueprint->decimal($name, 8, 2);
+                    }
+                    break;
+                case 'datetime':
+                    $column = $blueprint->dateTime($name);
+                    break;
+                case 'date':
+                    $column = $blueprint->date($name);
+                    break;
+                default:
+                    $column = $blueprint->string($name, $length ?? 255);
+            }
+
+            if ($default !== null && method_exists($column, 'default')) {
+                $column->default($default);
+            }
+        }
+    }
+
+    /**
+     * Execute query and try to create table/columns on missing table/column errors
+     */
+    protected static function runWithInitTable(callable $callback)
+    {
+        try {
+            return $callback();
+        } catch (QueryException $e) {
+            $msg = $e->getMessage();
+            if (stripos($msg, 'no such table') !== false ||
+                stripos($msg, 'base table or view not found') !== false ||
+                stripos($msg, 'doesn\'t exist') !== false ||
+                stripos($msg, 'unknown column') !== false) {
+                $table = (new static)->getTable();
+                self::initTable($table);
+                return $callback();
+            }
+
+            throw $e;
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary
- have BaseModel extend new CheckModel
- move table/column creation logic into CheckModel
- wrap BaseModel CRUD methods with error‑aware retries

## Testing
- `php -v` *(fails: command not found)*
- `composer -V` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68560923804c83269290c8df3d17f6a7