### PR TITLE
Add product auto translation

### DIFF
--- a/src/Controller/Admin/Ajax/ProductAjax.php
+++ b/src/Controller/Admin/Ajax/ProductAjax.php
@@ -14,6 +14,10 @@ use HugaShop\Models\Request;
 use App\Controller\BaseAdminController;
 use HugaShop\Models\Product\ProductOption;
 use HugaShop\Models\Product\ProductFeature;
+use HugaShop\Models\Product\Product;
+use HugaShop\Models\Config;
+use HugaShop\Models\Localization\Language;
+use OpenAI;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -99,5 +103,64 @@ class ProductAjax extends BaseAdminController
         $res->suggestions = $features_value;
 
         return new JsonResponse($res);
+    }
+
+
+    #[Route('/admin/ajax/product/translate')]
+    public function translate()
+    {
+
+        $this->checkAdminAccess('product_content');
+
+        if (!Request::checkCSRF()) {
+            return new JsonResponse(['error' => 'csrf'], 400);
+        }
+
+        $product_id = Request::post('product_id', 'integer');
+        $lang_code = Request::post('lang', 'string');
+
+        if (empty($product_id) || empty($lang_code)) {
+            return new JsonResponse(['error' => 'params'], 400);
+        }
+
+        Language::languageCatch();
+
+        if ($lang_code == Language::$main_language_code) {
+            return new JsonResponse(['error' => 'main_language'], 400);
+        }
+
+        $language = Language::where('code', $lang_code)->first();
+        if (empty($language)) {
+            return new JsonResponse(['error' => 'language'], 400);
+        }
+
+        $product = Product::query()->find($product_id);
+        if (empty($product)) {
+            return new JsonResponse(['error' => 'product'], 404);
+        }
+
+        Product::fillTranslation($product, Language::$main_language_code);
+
+        $key = Config::get('openai')->key;
+        if (empty($key)) {
+            return new JsonResponse(['error' => 'openai_key'], 500);
+        }
+
+        $client = OpenAI::client($key);
+
+        $translated = [];
+        foreach (Product::getTranslatableFields() as $field) {
+            if (!empty($product->$field)) {
+                $result = $client->chat()->create([
+                    'model' => 'gpt-4o',
+                    'messages' => [
+                        ['role' => 'user', 'content' => 'Переведи на ' . $language->name . ': ' . $product->$field],
+                    ],
+                ]);
+                $translated[$field] = trim($result->choices[0]->message->content);
+            }
+        }
+
+        return new JsonResponse($translated);
     }
 }

--- a/templates/admin/product/product.tpl
+++ b/templates/admin/product/product.tpl
@@ -10,11 +10,18 @@
 
 {block name=content}
 
-	<select id="language_select" class="form-select form-select w-auto me-auto mb-3">
-		{foreach $languages as $language}
-			<option value="{$language->code}" {if $current_language == $language->code}selected{/if}>{$language->name}</option>
-		{/foreach}
-	</select>
+        {foreach $languages as $lang}
+                {if $lang->main}{assign var=main_lang_code value=$lang->code}{/if}
+        {/foreach}
+
+        <select id="language_select" class="form-select form-select w-auto me-auto mb-3">
+                {foreach $languages as $language}
+                        <option value="{$language->code}" {if $current_language == $language->code}selected{/if}>{$language->name}</option>
+                {/foreach}
+        </select>
+        {if $current_language != $main_lang_code}
+                <button id="translate_button" type="button" class="btn btn-secondary ms-2 mb-3">Перевести</button>
+        {/if}
 
 	<!-- Основная форма -->
 	<form method="post" enctype="multipart/form-data">
@@ -361,11 +368,40 @@
 				$('input[name="url"]').change(function() { url_touched = true; });
 				$('input[name="name"]').keyup(function() { set_meta(); });
 
-				function set_meta() {
-					if (!url_touched)
-						$('input[name="url"]').val(generate_url());
-				}
-			});
-		{/literal}
-	</script>
+                                function set_meta() {
+                                        if (!url_touched)
+                                                $('input[name="url"]').val(generate_url());
+                                }
+
+                                $('#translate_button').on('click', function () {
+                                        const btn = $(this);
+                                        btn.prop('disabled', true);
+                                        $.ajax({
+                                                url: '/admin/ajax/product/translate',
+                                                type: 'POST',
+                                                dataType: 'json',
+                                                data: {
+                                                        product_id: $('input[name=id]').val(),
+                                                        lang: $('#language_select').val(),
+                                                        csrf: csrf
+                                                },
+                                                success: function (data) {
+                                                        for (const field in data) {
+                                                                const el = $('[name="' + field + '"]');
+                                                                if (field === 'body' && typeof tinymce !== 'undefined') {
+                                                                        tinymce.activeEditor.setContent(data[field]);
+                                                                } else if (el.length) {
+                                                                        el.val(data[field]);
+                                                                }
+                                                        }
+                                                },
+                                                complete: function () {
+                                                        btn.prop('disabled', false);
+                                                }
+                                        });
+                                        return false;
+                                });
+                        });
+                {/literal}
+        </script>
 {/block}


### PR DESCRIPTION
## Summary
- allow translating product fields via OpenAI
- show `Перевести` button next to language selector
- use AJAX endpoint to fill translated fields

## Testing
- `php -l src/Controller/Admin/Ajax/ProductAjax.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858e41aae3083269c9cfc9ce3ffa815