### PR TITLE
Add RedirectUrl extension

### DIFF
--- a/hugashop/crm/Extensions/RedirectUrl/Models/RedirectUrl.php
+++ b/hugashop/crm/Extensions/RedirectUrl/Models/RedirectUrl.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace HugaShop\Extensions\RedirectUrl\Models;
+
+use HugaShop\Extensions\BaseExtensionModel;
+
+final class RedirectUrl extends BaseExtensionModel
+{
+    protected static $table_fields = [
+        'id'         => ['type' => 'int',     'extra' => 'AUTO_INCREMENT'],
+        'url'        => ['type' => 'varchar', 'required' => true],
+        'redirect'   => ['type' => 'varchar', 'required' => true],
+        'enabled'    => ['type' => 'tinyint', 'def' => 1],
+        'transitions'=> ['type' => 'int',     'def' => 0],
+    ];
+}

--- a/hugashop/crm/Extensions/RedirectUrl/RedirectUrl.php
+++ b/hugashop/crm/Extensions/RedirectUrl/RedirectUrl.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace HugaShop\Extensions\RedirectUrl;
+
+use HugaShop\Models\Design;
+use HugaShop\Models\Helper;
+use HugaShop\Models\Request;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use HugaShop\Extensions\BaseExtension;
+use HugaShop\Extensions\RedirectUrl\Models\RedirectUrl as RedirectUrlModel;
+
+final class RedirectUrl extends BaseExtension
+{
+    public function updateOne($id, $entity)
+    {
+        RedirectUrlModel::updateOne($id, $entity);
+    }
+
+    public function index()
+    {
+        if (Request::checkCSRF()) {
+            $ids = Request::post('check');
+            if (is_array($ids)) {
+                switch (Request::post('action')) {
+                    case 'disable':
+                        RedirectUrlModel::updateOne($ids, ['enabled' => 0]);
+                        break;
+                    case 'enable':
+                        RedirectUrlModel::updateOne($ids, ['enabled' => 1]);
+                        break;
+                    case 'delete':
+                        foreach ($ids as $id) {
+                            RedirectUrlModel::deleteOne($id);
+                        }
+                        break;
+                }
+            }
+        }
+
+        $links = RedirectUrlModel::getList();
+        Design::assign('links', $links);
+
+        return $this->getTemplatePath('templates/link_list.tpl');
+    }
+
+    public function link(?int $id = null)
+    {
+        if (!empty($link = Request::getDataAcces(RedirectUrlModel::getFields()))) {
+            if (empty($link->id)) {
+                $link = Design::setFlashMessage('add', RedirectUrlModel::create($link));
+            } else {
+                Design::setFlashMessage('update', RedirectUrlModel::updateOne($link->id, $link));
+            }
+            Request::makeRedirect("/admin/extension/RedirectUrl/link/$link->id");
+        }
+
+        if (!empty($id)) {
+            $link = RedirectUrlModel::getOne($id);
+            if (empty($link->id)) {
+                Request::makeRedirect('/admin/extension/RedirectUrl');
+            }
+        }
+
+        Design::assign('link', $link);
+        return $this->getTemplatePath('templates/link.tpl');
+    }
+
+    #[AsEventListener(priority: 128)]
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest() || Request::isAjax() || Design::getTheme() === 'admin') {
+            return;
+        }
+
+        $uri = urldecode($event->getRequest()->getPathInfo());
+
+        $cache = Helper::cache(self::class);
+        $cache_item = $cache->getItem('redirect_list');
+        if (!$cache_item->isHit()) {
+            $cache_item->set(RedirectUrlModel::getList(['enabled' => 1]));
+            $cache->save($cache_item);
+        }
+        $links = $cache_item->get();
+
+        foreach ($links as $link) {
+            $pattern = '#^' . $link->url . '$#u';
+            if (preg_match($pattern, $uri, $m)) {
+                $redirect = $link->redirect;
+                foreach ($m as $i => $v) {
+                    if ($i === 0) continue;
+                    $redirect = str_replace("[$i]", $v, $redirect);
+                }
+                RedirectUrlModel::updateOne($link->id, ['transitions' => $link->transitions + 1]);
+                Request::makeRedirect($redirect, '301');
+            }
+        }
+    }
+}

--- a/hugashop/crm/Extensions/RedirectUrl/settings.yaml
+++ b/hugashop/crm/Extensions/RedirectUrl/settings.yaml
@@ -1,0 +1,2 @@
+name: "Redirect URL"
+description: "Перенаправление со старых адресов на новые"

--- a/hugashop/crm/Extensions/RedirectUrl/templates/link.tpl
+++ b/hugashop/crm/Extensions/RedirectUrl/templates/link.tpl
@@ -1,0 +1,61 @@
+{extends 'wrapper/main.tpl'}
+{include 'extension/parts/menu_part.tpl'}
+
+{if $link->id}
+        {$meta_title = $link->url}
+{else}
+        {$meta_title = 'Новая ссылка'}
+{/if}
+
+{block name=content}
+
+        <form method="post" enctype="multipart/form-data">
+                <input name="id" type="hidden" value="{$link->id}" />
+                {getCSRFInput}
+
+                <div class="row gx-5">
+                        <div class="col-12">
+                                <div class="over_name">
+                                        <div class="checkbox_line">
+                                                <div class="form-check">
+                                                        <input class="form-check-input" name="enabled" value="1" type="checkbox" id="enabled" {if $link->enabled}checked{/if} />
+                                                        <label class="form-check-label" for="enabled">Активна</label>
+                                                </div>
+                                        </div>
+                                </div>
+
+                                <div class="name_row">
+                                        <span class="item_id">#{$link->id}</span>
+                                </div>
+                        </div>
+
+                        <div class="col-lg-6 layer">
+                                <h2>Источник</h2>
+                                <ul class="property_block">
+                                        <li>
+                                                <label class="col-form-label" for="url">URL ссылки (regexp)</label>
+                                                <input class="form-control" id="url" name="url" type="text" value="{$link->url}" />
+                                        </li>
+                                </ul>
+                        </div>
+
+                        <div class="col-lg-6 layer">
+                                <h2>Редирект</h2>
+                                <ul class="property_block">
+                                        <li>
+                                                <label class="col-form-label" for="redirect">URL редиректа</label>
+                                                <input class="form-control" id="redirect" name="redirect" type="text" value="{$link->redirect}" />
+                                        </li>
+                                        <li>
+                                                <label class="col-form-label">Переходов</label>
+                                                <input class="form-control" type="text" value="{$link->transitions}" disabled />
+                                        </li>
+                                </ul>
+                        </div>
+
+                        <div class="col-12 btn_row">
+                                <button class="btn btn-primary" type="submit">Сохранить</button>
+                        </div>
+                </div>
+        </form>
+{/block}

--- a/hugashop/crm/Extensions/RedirectUrl/templates/link_list.tpl
+++ b/hugashop/crm/Extensions/RedirectUrl/templates/link_list.tpl
@@ -1,0 +1,70 @@
+{extends 'wrapper/main.tpl'}
+{include 'extension/parts/menu_part.tpl'}
+
+{$meta_title='Redirect URL'}
+
+{block name=content}
+
+        <div class="header_top">
+                <h1>{$meta_title}</h1>
+                <a class="add" href="/admin/extension/{$extension->module}/link">Добавить ссылку</a>
+        </div>
+
+        <div id="main_list">
+                {if $links}
+                        <form method="post" class="list_form">
+                                {getCSRFInput}
+                                <div class="list">
+                                        {foreach $links as $l}
+                                                <div class="{if !$l->enabled}enabled_off{/if} list_row">
+                                                        <div class="checkbox">
+                                                                <input class="form-check-input" type="checkbox" name="check[]" value="{$l->id}" />
+                                                        </div>
+                                                        <div class="row col">
+                                                                <div class="col-12 col-sm-8">
+                                                                        <a href="/admin/extension/{$extension->module}/link/{$l->id}">{$l->url}</a>
+                                                                </div>
+                                                                <div class="col-12 col-sm-4 text-end">
+                                                                        <span class="badge text-bg-round">{$l->transitions}</span>
+                                                                </div>
+                                                        </div>
+                                                        <div class="icons">
+                                                                <i class="enable material-icons visibility" data-bs-toggle="tooltip" title="Активна"></i>
+                                                                <i class="delete material-icons" data-bs-toggle="tooltip" title="Удалить">cancel</i>
+                                                        </div>
+                                                </div>
+                                        {/foreach}
+                                </div>
+                                <div id="action">
+                                        <span id="check_all" class="dash_link">Выбрать все</span>
+                                        <span id="select">
+                                                <select class="form-select" name="action">
+                                                        <option value="">Выбрать действие</option>
+                                                        <option value="enable">Сделать видимыми</option>
+                                                        <option value="disable">Сделать невидимыми</option>
+                                                        <option value="delete">Удалить</option>
+                                                </select>
+                                        </span>
+                                        <button class="btn btn-primary apply" id="apply_action" type="submit">Применить</button>
+                                </div>
+                        </form>
+                {else}
+                        Нет ссылок
+                {/if}
+        </div>
+{/block}
+
+{block name=body_script append}
+        <script type="module">
+                var csrf = "{setCSRF}";
+                import { ajax_icon } from '{"js/common.js"|asset}';
+                {literal}
+                        $(function() {
+                                $("i.enable").click(function() {
+                                        ajax_icon($(this), 'RedirectUrl', 'enabled', csrf);
+                                        return false;
+                                });
+                        });
+                {/literal}
+        </script>
+{/block}


### PR DESCRIPTION
## Summary
- add RedirectUrl extension with model and event listener
- implement admin pages to manage redirect rules

## Testing
- `php` and `composer` not available, so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_6858f1b8be70832686edd916834b1dca