### PR TITLE
Universal translation button

### DIFF
--- a/src/Controller/Admin/Ajax/TranslateAjax.php
+++ b/src/Controller/Admin/Ajax/TranslateAjax.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace App\Controller\Admin\Ajax;
+
+use OpenAI;
+use HugaShop\Models\Config;
+use HugaShop\Models\Request;
+use App\Controller\BaseAdminController;
+use HugaShop\Models\Localization\Language;
+use HugaShop\Models\Product\Product;
+use HugaShop\Models\Content\ContentPost;
+use HugaShop\Models\Content\ContentPage;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class TranslateAjax extends BaseAdminController
+{
+    #[Route('/admin/ajax/translate', name: 'TranslateAjaxAdmin')]
+    public function translate()
+    {
+        if (!Request::checkCSRF()) {
+            return new JsonResponse(['error' => 'csrf'], 400);
+        }
+
+        $entity    = Request::post('entity', 'string');
+        $id        = Request::post('id', 'integer');
+        $lang_code = Request::post('lang', 'string');
+
+        if (empty($entity) || empty($id) || empty($lang_code)) {
+            return new JsonResponse(['error' => 'params'], 400);
+        }
+
+        Language::languageCatch();
+
+        if ($lang_code == Language::$main_language->code) {
+            return new JsonResponse(['error' => 'main_language'], 400);
+        }
+
+        $language = Language::where('code', $lang_code)->first();
+        if (empty($language)) {
+            return new JsonResponse(['error' => 'language'], 400);
+        }
+
+        $model = null;
+        switch ($entity) {
+            case 'product':
+                $this->checkAdminAccess('product_content');
+                $model = Product::query()->find($id);
+                break;
+            case 'blog':
+                $this->checkAdminAccess('blog');
+                $model = ContentPost::query()->find($id);
+                break;
+            case 'page':
+                $this->checkAdminAccess('page');
+                $model = ContentPage::query()->find($id);
+                break;
+            default:
+                return new JsonResponse(['error' => 'entity'], 400);
+        }
+
+        if (empty($model)) {
+            return new JsonResponse(['error' => 'not_found'], 404);
+        }
+
+        $key = Config::get('openai')->key;
+        if (empty($key)) {
+            return new JsonResponse(['error' => 'openai_key'], 500);
+        }
+
+        $client = OpenAI::client($key);
+
+        $translated = [];
+        foreach ($model::getTranslatableFields() as $field) {
+            if (!empty($model->$field)) {
+                $result = $client->chat()->create([
+                    'model' => 'gpt-4o',
+                    'messages' => [
+                        ['role' => 'user', 'content' => 'Переведи на ' . $language->name . ': ' . $model->$field],
+                    ],
+                ]);
+                $translated[$field] = trim($result->choices[0]->message->content);
+            }
+        }
+
+        return new JsonResponse($translated);
+    }
+}

--- a/templates/admin/content/page.tpl
+++ b/templates/admin/content/page.tpl
@@ -9,7 +9,7 @@
 
 {block name=content}
 
-	{include 'parts/translation_btn_part.tpl'}
+        {include 'parts/translation_btn_part.tpl' entity='page'}
 
 	<!-- Основная форма -->
 	<form method="post" enctype="multipart/form-data">

--- a/templates/admin/content/post.tpl
+++ b/templates/admin/content/post.tpl
@@ -9,7 +9,7 @@
 
 {block name=content}
 
-	{include 'parts/translation_btn_part.tpl'}
+        {include 'parts/translation_btn_part.tpl' entity='blog'}
 
 	<!-- Основная форма -->
 	<form method="post" enctype="multipart/form-data">

--- a/templates/admin/parts/translation_btn_part.tpl
+++ b/templates/admin/parts/translation_btn_part.tpl
@@ -21,6 +21,7 @@
 
     {block name=body_script append}
         <script type="module">
+            const entity = '{$entity|default:"product"}';
             {literal}
 
                 $('#translate_button').on('click', function() {
@@ -29,11 +30,12 @@
                     btn.prop('disabled', true);
 
                     $.ajax({
-                        url: '/admin/ajax/product/translate',
+                        url: '/admin/ajax/translate',
                         type: 'POST',
                         dataType: 'json',
                         data: {
-                            product_id: $('input[name=id]').val(),
+                            entity: entity,
+                            id: $('input[name=id]').val(),
                             lang: $('#language_select').val(),
                             csrf: csrf
                         },

--- a/templates/admin/product/brand.tpl
+++ b/templates/admin/product/brand.tpl
@@ -9,7 +9,7 @@
 
 {block name=content}
 
-	{include 'parts/translation_btn_part.tpl'}
+        {include 'parts/translation_btn_part.tpl' entity='brand'}
 
 	<!-- Основная форма -->
 	<form method="post" enctype="multipart/form-data">

--- a/templates/admin/product/feature.tpl
+++ b/templates/admin/product/feature.tpl
@@ -9,7 +9,7 @@
 
 {block name=content}
 
-	{include 'parts/translation_btn_part.tpl'}
+        {include 'parts/translation_btn_part.tpl' entity='feature'}
 
 	<!-- Основная форма -->
 	<form method="post">

--- a/templates/admin/product/product.tpl
+++ b/templates/admin/product/product.tpl
@@ -10,7 +10,7 @@
 
 {block name=content}
 
-	{include 'parts/translation_btn_part.tpl'}
+        {include 'parts/translation_btn_part.tpl' entity='product'}
 
 	<!-- Основная форма -->
 	<form method="post" enctype="multipart/form-data">


### PR DESCRIPTION
## Summary
- add `TranslateAjax` controller to handle translating multiple entity types
- update translation button partial to send entity name and use new route
- pass entity info when including the translation button in edit templates

## Testing
- `php composer.phar validate --no-check-all` *(fails: php not available)*

------
https://chatgpt.com/codex/tasks/task_e_685a0fe812c08326ae1a7d8edc718520