### PR TITLE
Fix GoogleDataLayer currency init

### DIFF
--- a/hugashop/crm/Extensions/GoogleDataLayer/GoogleDataLayer.php
+++ b/hugashop/crm/Extensions/GoogleDataLayer/GoogleDataLayer.php
@@ -11,6 +11,7 @@
 
 namespace HugaShop\Extensions\GoogleDataLayer;
 
+use HugaShop\Models\Finance\FinanceCurrency;
 use HugaShop\Extensions\BaseExtension;
 
 final class GoogleDataLayer extends BaseExtension
@@ -18,11 +19,16 @@ final class GoogleDataLayer extends BaseExtension
     /**
      * Get block template
      */
-    public function getFrontBodyTemplate()
+    public function getFrontBodyTemplate(): ?string
     {
-        if (!empty($this->ext_settings->enabled)) {
-            return $this->fetchTemplate('datalayer.tpl');
+        if (empty($this->ext_settings->enabled)) {
+            return null;
         }
-        return;
+
+        if (empty($this->ext_settings->currency_code)) {
+            $this->ext_settings->currency_code = FinanceCurrency::getMainCurrency()->code;
+        }
+
+        return $this->fetchTemplate('datalayer.tpl');
     }
 }


### PR DESCRIPTION
## Summary
- initialize currency code for Google DataLayer if not provided

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6ad960a88326b9aa04653f6901dd