### PR TITLE
Fix FacebookCommerce feed generator

### DIFF
--- a/hugashop/crm/Extensions/FacebookCommerce/Models/FacebookCommerceCategory.php
+++ b/hugashop/crm/Extensions/FacebookCommerce/Models/FacebookCommerceCategory.php
@@ -31,9 +31,9 @@ class FacebookCommerceCategory extends BaseExtensionModel
 
 
     /**
-     * Устанавливаем варинат в прайслист
+     * Устанавливаем категории для прайса
      * @param int $pricefeed_id
-     * @param int $pricefeed_id
+     * @param array $category_ids
      */
     public static function setCategories(int $pricefeed_id, array $category_ids = [])
     {

--- a/hugashop/crm/Extensions/FacebookCommerce/Models/FeedGenerator.php
+++ b/hugashop/crm/Extensions/FacebookCommerce/Models/FeedGenerator.php
@@ -77,8 +77,15 @@ class FeedGenerator
 
             $pricefeed_categories = FacebookCommerceCategory::getCategoriesIds(self::$pricefeed->id);
 
-            // TODO: Select all child categories
-            $filter['category_id'] = $pricefeed_categories;
+            // Include children categories
+            $categories = [];
+            foreach ($pricefeed_categories as $category_id) {
+                $category = ProductCategory::getCategory($category_id);
+                if (!empty($category->children)) {
+                    $categories = array_merge($categories, $category->children);
+                }
+            }
+            $filter['category_id'] = array_values(array_unique($categories ?: $pricefeed_categories));
             $filter['visible'] = 1;
             $products = Product::getList($filter, order: 'position', join: ['image', 'brand']);
 


### PR DESCRIPTION
## Summary
- update categories handling in FacebookCommerce feed generator
- clarify docs in FacebookCommerceCategory

## Testing
- `composer validate --no-check-all` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6b02ebd88326aff976da389efb97