### PR TITLE
Fix category labels in google merchant feed

### DIFF
--- a/hugashop/crm/Extensions/GoogleMerchant/Models/FeedGenerator.php
+++ b/hugashop/crm/Extensions/GoogleMerchant/Models/FeedGenerator.php
@@ -140,11 +140,16 @@ class FeedGenerator
                  * @link https://support.google.com/merchants/answer/6324406?sjid=9520931803415694483-NC
                  */
                 $product_category = ProductCategory::getCategory($product_raw->category_id);
+                $categories_array = [];
                 if (!empty($product_category)) {
                     foreach ($product_category->path as $cat) {
                         $categories_array[] = $cat->name;
                     }
-                    $product->product_type = join(" > ", $categories_array);
+                    $product->product_type = join(' > ', $categories_array);
+
+                    if (!empty($product_category->url)) {
+                        $product->label_1 = $product_category->url;
+                    }
                 }
 
 
@@ -170,10 +175,6 @@ class FeedGenerator
                  */
                 if (!empty(self::$pricefeed->label)) {
                     $product->label_0 = self::$pricefeed->label;
-                }
-
-                if (!empty($product_category->url)) {
-                    $product->label_1 = $product_category->url;
                 }
 
                 $feed_data[] = $product;


### PR DESCRIPTION
## Summary
- reset category names per product to avoid bleed over
- guard assignment of custom label

## Testing
- `php -l hugashop/crm/Extensions/GoogleMerchant/Models/FeedGenerator.php` *(fails: command not found)*
- `composer validate --no-check-all` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6b8d530c8326ac95bd0709abc795