### PR TITLE
Fix GoogleSiteTranslator cookie path

### DIFF
--- a/assets/extensions/GoogleSiteTranslator/translator.js
+++ b/assets/extensions/GoogleSiteTranslator/translator.js
@@ -82,7 +82,7 @@ function TranslateGetCode(config) {
 function TranslateCookieHandler(val) {
 
     /* Writing down cookies */
-    Cookies.set("googtrans", val);
+    Cookies.set("googtrans", val, { path: "/" });
 }
 
 function TranslateEventHandler(event, selector, handler) {

--- a/hugashop/crm/Extensions/GoogleSiteTranslator/GoogleSiteTranslator.php
+++ b/hugashop/crm/Extensions/GoogleSiteTranslator/GoogleSiteTranslator.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.5
+ * @version 1.6
  * 
  * @link https://github.com/get-web/google-translate-custom-widget
  *

--- a/hugashop/crm/Extensions/GoogleSiteTranslator/settings.yaml
+++ b/hugashop/crm/Extensions/GoogleSiteTranslator/settings.yaml
@@ -19,4 +19,4 @@ settings:
       name: "Использовать свой вид",
       options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }],
     }
-version: 2.0
+version: 2.1


### PR DESCRIPTION
## Summary
- fix cookie path in the translation helper
- bump extension versions

## Testing
- `php -l hugashop/crm/Extensions/GoogleSiteTranslator/GoogleSiteTranslator.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6e57c10c83269f7e2224b5d81376