### PR TITLE
Fix SchemaOrg extension metadata

### DIFF
--- a/hugashop/crm/Extensions/SchemaOrg/SchemaOrg.php
+++ b/hugashop/crm/Extensions/SchemaOrg/SchemaOrg.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.4
+ * @version 1.5
  * 
  * @link https://schema.org/
  *

--- a/hugashop/crm/Extensions/SchemaOrg/settings.yaml
+++ b/hugashop/crm/Extensions/SchemaOrg/settings.yaml
@@ -1,5 +1,5 @@
 name: "SchemaOrg"
-description: "Добавляет на сайт Google tag"
+description: "Добавляет на сайт разметку Schema.org"
 settings:
   - {
       variable: enabled,
@@ -9,4 +9,4 @@ settings:
   - { variable: country_code, name: "Код страны" }
   - { variable: return_days, name: "Дней на возврат" }
   - { variable: shipping_cost, name: "Стоимость доставки" }
-version: 1.3
+version: 1.4


### PR DESCRIPTION
## Summary
- update SchemaOrg extension description
- bump SchemaOrg extension version numbers

## Testing
- `composer validate --no-check-all` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6e8adb348326828cefd9a8207b61