### PR TITLE
Move SeoLinker links map to detail page

### DIFF
--- a/hugashop/crm/Extensions/SeoLinker/SeoLinker.php
+++ b/hugashop/crm/Extensions/SeoLinker/SeoLinker.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.1
+ * @version 1.2
  * 
  * SeoLinker extension
  * @link https://github.com/spatie/crawler
@@ -16,6 +16,7 @@ namespace HugaShop\Extensions\SeoLinker;
 use HugaShop\Models\Config;
 use HugaShop\Models\Design;
 use HugaShop\Models\Request;
+use HugaShop\Models\Settings;
 use HugaShop\Extensions\BaseExtension;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use HugaShop\Extensions\SeoLinker\Services\ScanBatch;
@@ -55,18 +56,37 @@ final class SeoLinker extends BaseExtension
             }
         }
 
-        $pages = SeoLinkerModel::getList(order: ['in_internal', 'desc']);
-        $linksMap = [];
-        foreach ($pages as $p) {
-            $linksMap[$p->url] = SeoLinkerLinkModel::getList(['from_url' => $p->url]);
-        }
+        $filter = [];
+        $filter['page'] = max(1, Request::get('page', 'int'));
+        $filter['limit'] = Request::get('page', 'string') == 'all' ? 'all' : Settings::getParam('products_num_admin');
+
+        $pages = SeoLinkerModel::getList($filter, order: ['in_internal', 'desc']);
+        $pages_count = SeoLinkerModel::getCount();
 
         Design::assign('pages', $pages);
-        Design::assign('links_map', $linksMap);
+        Design::assign('pages_count', ceil($pages_count / Settings::getParam('products_num_admin')));
+        Design::assign('current_page', $filter['limit'] == 'all' ? 'all' : $filter['page']);
 
         return $this->getTemplatePath('templates/report.tpl');
     }
 
 
-    public function page(?int $id = null) {}
+    public function page(?int $id = null)
+    {
+        if (empty($id)) {
+            Request::makeRedirect('/admin/extension/SeoLinker');
+        }
+
+        $page = SeoLinkerModel::getOne($id);
+        if (empty($page)) {
+            Request::makeRedirect('/admin/extension/SeoLinker');
+        }
+
+        $links = SeoLinkerLinkModel::getList(['from_url' => $page->url]);
+
+        Design::assign('page', $page);
+        Design::assign('links', $links);
+
+        return $this->getTemplatePath('templates/page.tpl');
+    }
 }

--- a/hugashop/crm/Extensions/SeoLinker/templates/page.tpl
+++ b/hugashop/crm/Extensions/SeoLinker/templates/page.tpl
@@ -1,0 +1,30 @@
+{extends 'wrapper/main.tpl'}
+{include 'extension/parts/menu_part.tpl'}
+
+{$meta_title=$page->url}
+
+{block name=content}
+    <div class="header_top">
+        <h1>{$page->url}</h1>
+    </div>
+    <div id="main_list">
+        {if $links}
+            <div class="list">
+                {foreach $links as $ln}
+                    <div class="list_row">
+                        <div class="row col">
+                            <div class="col-12 col-lg-8 text-break">
+                                <a href="{$ln->to_url}" target="_blank">{$ln->to_url}</a>
+                            </div>
+                            <div class="col-12 col-lg-4 text-end">
+                                <span class="badge text-bg-round">{$ln->type}</span>
+                            </div>
+                        </div>
+                    </div>
+                {/foreach}
+            </div>
+        {else}
+            Нет ссылок
+        {/if}
+    </div>
+{/block}

--- a/hugashop/crm/Extensions/SeoLinker/templates/report.tpl
+++ b/hugashop/crm/Extensions/SeoLinker/templates/report.tpl
@@ -11,30 +11,23 @@
     </div>
     <div id="main_list">
         {if $pages}
+            {include file='parts/pagination.tpl'}
             <div class="list">
                 {foreach $pages as $p}
                     <div class="list_row">
                         <div class="row col">
-                            <div class="col-12 col-lg-4 text-break">{$p->url}</div>
+                            <div class="col-12 col-lg-4 text-break">
+                                <a href="/admin/extension/{$extension->module}/page/{$p->id}">{$p->url}</a>
+                            </div>
                             <div class="col-3 col-lg-2"><span class="badge text-bg-round">{$p->depth}</span></div>
                             <div class="col-3 col-lg-2"><span class="badge text-bg-round">{$p->out_internal}</span></div>
                             <div class="col-3 col-lg-2"><span class="badge text-bg-round">{$p->out_external}</span></div>
                             <div class="col-3 col-lg-2 text-end"><span class="badge text-bg-round">{$p->in_internal}</span></div>
                         </div>
                     </div>
-                    {if $links_map[$p->url]}
-                        <div class="list_row bg-light">
-                            <div class="col">
-                                <ul class="mb-0 small">
-                                    {foreach $links_map[$p->url] as $ln}
-                                        <li><a href="{$ln->to_url}" target="_blank">{$ln->to_url}</a> ({$ln->type})</li>
-                                    {/foreach}
-                                </ul>
-                            </div>
-                        </div>
-                    {/if}
                 {/foreach}
             </div>
+            {include file='parts/pagination.tpl'}
         {else}
             Нет ссылок
         {/if}


### PR DESCRIPTION
## Summary
- bump SeoLinker version
- add pagination to SEO links list
- show outgoing links on a dedicated page instead of list

## Testing
- `composer -V` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dea0f8f288326a0410340bc8cf6be