### PR TITLE
Add page count to SeoLinker header

### DIFF
--- a/hugashop/crm/Extensions/SeoLinker/SeoLinker.php
+++ b/hugashop/crm/Extensions/SeoLinker/SeoLinker.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.2
+ * @version 1.3
  * 
  * SeoLinker extension
  * @link https://github.com/spatie/crawler
@@ -58,6 +58,7 @@ final class SeoLinker extends BaseExtension
         $pages_count = SeoLinkerModel::getCount();
 
         Design::assign('pages', $pages);
+        Design::assign('pages_total', $pages_count);
         Design::assign('pages_count', ceil($pages_count / Settings::getParam('products_num_admin')));
         Design::assign('current_page', $filter['limit'] == 'all' ? 'all' : $filter['page']);
 

--- a/hugashop/crm/Extensions/SeoLinker/templates/report.tpl
+++ b/hugashop/crm/Extensions/SeoLinker/templates/report.tpl
@@ -5,7 +5,11 @@
 
 {block name=content}
     <div class="header_top">
-        <h1>{$meta_title}</h1>
+        {if $pages_total > 0}
+            <h1>{$meta_title} <span class="sum_total">{$pages_total} {$pages_total|plural:'страница':'страниц':'страницы'}</span></h1>
+        {else}
+            <h1>{$meta_title}</h1>
+        {/if}
         <button id="scan_button" class="btn btn-primary ms-2">Сканировать</button>
         <span id="scan_count" class="badge text-bg-round ms-2"></span>
     </div>


### PR DESCRIPTION
## Summary
- show total number of scanned pages in SeoLinker report header

## Testing
- `php -l hugashop/crm/Extensions/SeoLinker/SeoLinker.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dee35da408326909c36c57bd8511c