### PR TITLE
Limit SeoLinker crawler to HTML

### DIFF
--- a/hugashop/crm/Extensions/SeoLinker/Services/ScanBatch.php
+++ b/hugashop/crm/Extensions/SeoLinker/Services/ScanBatch.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.3
+ * @version 1.4
  *
  */
 
@@ -108,6 +108,7 @@ final class ScanBatch
             //->acceptNofollowLinks()
             ->setCrawlProfile(new CrawlInternalUrls($url))
             ->setMaximumDepth(0)
+            ->setParseableMimeTypes(['text/html'])
             ->startCrawling($url);
 
         $res = $observer->results[$url] ?? ['out_internal' => 0, 'out_external' => 0];


### PR DESCRIPTION
## Summary
- restrict SeoLinker crawler to scan only HTML pages
- bump version in ScanBatch service

## Testing
- `php -l hugashop/crm/Extensions/SeoLinker/Services/ScanBatch.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685df43d7b7c8326a141bdadd42d4893