### PR TITLE
Add settings pages for extensions

### DIFF
--- a/src/Controller/Admin/Extension/ExtensionController.php
+++ b/src/Controller/Admin/Extension/ExtensionController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.9
+ * @version 2.0
  *
  */
 
@@ -30,8 +30,9 @@ class ExtensionController extends BaseAdminController
             return $this->redirectToRoute('ExtensionListAdmin');
         }
 
-        $extension            = clone $Extension->getConfig();
-        $extension->settings  = $Extension->ext_settings;
+        $extension                     = clone $Extension->getConfig();
+        $extension->settings_structure = $extension->settings ?? [];
+        $extension->settings           = $Extension->ext_settings;
         Design::assign('extension', $extension);
 
         if (method_exists($Extension, 'index')) {
@@ -49,6 +50,19 @@ class ExtensionController extends BaseAdminController
     }
 
 
+    #[Route('/admin/extension/{name}/settings', name: 'ExtensionSettingsAdmin', priority: 2)]
+    public function settingsPage(string $name): Response
+    {
+        $this->checkAdminAccess('extension');
+
+        if (empty($Extension = Extension::makeExtension($name))) {
+            return $this->redirectToRoute('ExtensionListAdmin');
+        }
+
+        return $this->settings($Extension);
+    }
+
+
     #[Route('/admin/extension/{name}/{path}', name: 'ExtensionItemNewAdmin')]
     #[Route('/admin/extension/{name}/{path}/{item_id}', requirements: ['id' => '\d+', 'item_id' => '\d+'], name: 'ExtensionItemAdmin')]
     public function path(string $name, string $path, ?int $item_id = null): Response
@@ -60,8 +74,11 @@ class ExtensionController extends BaseAdminController
             return $this->redirectToRoute('ExtensionListAdmin');
         }
 
-        Design::assign('extension', $Extension->ext_config);
-        Design::assign('extension_settings', $Extension->ext_settings);
+        $extension                     = clone $Extension->getConfig();
+        $extension->settings_structure = $extension->settings ?? [];
+        $extension->settings           = $Extension->ext_settings;
+
+        Design::assign('extension', $extension);
 
         return $this->fetchResponse($Extension->$path($item_id));
     }
@@ -79,6 +96,11 @@ class ExtensionController extends BaseAdminController
             return $this->redirectToRoute('ExtensionAdmin', ['name' => $Extension->getName()]);
         }
 
+        $extension                     = clone $Extension->getConfig();
+        $extension->settings_structure = $extension->settings ?? [];
+        $extension->settings           = $Extension->ext_settings;
+
+        Design::assign('extension', $extension);
         Design::assign('extensions', [$Extension->getName() => $Extension->getConfig()]);
 
         return $this->fetchResponse('extension/extension.tpl');

--- a/templates/admin/extension/parts/menu_part.tpl
+++ b/templates/admin/extension/parts/menu_part.tpl
@@ -7,10 +7,16 @@
 	{/if}
 
 
-	{if !$extension->module|empty and 'extension'|user_access}
-		<li class="mini {if $route|in_array:[ExtensionAdmin, ExtensionItemNewAdmin, ExtensionItemAdmin]}active{/if}">
-			<a href="/admin/extension/{$extension->module}">{$extension->name}</a>
-		</li>
-	{/if}
+        {if !$extension->module|empty and 'extension'|user_access}
+                <li class="mini {if $route|in_array:[ExtensionAdmin, ExtensionItemNewAdmin, ExtensionItemAdmin]}active{/if}">
+                        <a href="/admin/extension/{$extension->module}">{$extension->name}</a>
+                </li>
+
+                {if $extension->settings_structure|@count > 0}
+                        <li class="mini {if $route == 'ExtensionSettingsAdmin'}active{/if}">
+                                <a href="/admin/extension/{$extension->module}/settings">Настройки</a>
+                        </li>
+                {/if}
+        {/if}
 
 {/block}


### PR DESCRIPTION
## Summary
- enable dedicated settings view for extensions via `/admin/extension/<name>/settings`
- expose extension settings tab in menu when configuration contains settings

## Testing
- `composer validate --no-check-publish` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685df9fe86c08326a612dfca8588a7b2