### PR TITLE
Fix SeoLinker internal link classification

### DIFF
--- a/hugashop/crm/Extensions/SeoLinker/Services/CrawlerObserver.php
+++ b/hugashop/crm/Extensions/SeoLinker/Services/CrawlerObserver.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.2
+ * @version 1.3
  *
  */
 
@@ -82,7 +82,9 @@ final class CrawlerObserver extends CrawlObserver
                 continue;
             }
 
-            if (($p['host'] ?? '') === $this->host) {
+            $scheme = strtolower($p['scheme'] ?? $this->scheme);
+
+            if (($p['host'] ?? '') === $this->host && $scheme === strtolower($this->scheme)) {
                 $outInternal++;
                 $this->links[] = [
                     'from_url' => $current,


### PR DESCRIPTION
## Summary
- bump version of `CrawlerObserver`
- treat links with a different URL scheme as external

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e01c6d17c832684b17bc73eca7651