### PR TITLE
Fix tg link handling in SeoLinker

### DIFF
--- a/hugashop/crm/Extensions/SeoLinker/Services/CrawlerObserver.php
+++ b/hugashop/crm/Extensions/SeoLinker/Services/CrawlerObserver.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.3
+ * @version 1.4
  *
  */
 
@@ -58,7 +58,8 @@ final class CrawlerObserver extends CrawlObserver
                 str_starts_with($href, '#') ||
                 str_starts_with(strtolower($href), 'javascript:') ||
                 str_starts_with($href, 'mailto:') ||
-                str_starts_with($href, 'tel:')
+                str_starts_with($href, 'tel:') ||
+                str_starts_with(strtolower($href), 'tg:')
             ) {
                 continue;
             }
@@ -119,7 +120,8 @@ final class CrawlerObserver extends CrawlObserver
         ?string $linkText = null,
     ): void {
 
-        dd($requestException);
+        // Ignore crawl errors such as unsupported protocols
+        return;
     }
 
     
@@ -138,6 +140,10 @@ final class CrawlerObserver extends CrawlObserver
             return $this->scheme . ':' . $href;
         }
         if ($href === '') {
+            return null;
+        }
+
+        if (preg_match('/^[a-zA-Z][a-zA-Z0-9+.-]*:/', $href) && !preg_match('/^https?:\/\//i', $href)) {
             return null;
         }
 


### PR DESCRIPTION
## Summary
- avoid crashing when crawler encounters unsupported protocols
- ignore `tg:` links when parsing pages
- guard against non-http links
- bump version on `CrawlerObserver`

## Testing
- `php -l hugashop/crm/Extensions/SeoLinker/Services/CrawlerObserver.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e2588819c83268e7d4f622ade2f1e