### PR TITLE
Add inbound links list to SeoLinker page view

### DIFF
--- a/hugashop/crm/Extensions/SeoLinker/SeoLinker.php
+++ b/hugashop/crm/Extensions/SeoLinker/SeoLinker.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.3
+ * @version 1.5
  * 
  * SeoLinker extension
  * @link https://github.com/spatie/crawler
@@ -80,8 +80,19 @@ final class SeoLinker extends BaseExtension
 
         $links = SeoLinkerLink::getList(['from_url' => $page->url]);
 
+        $links_in = SeoLinkerLink::getList([
+            'to_url' => $page->url,
+            'type'   => 'internal',
+        ]);
+
+        foreach ($links_in as $ln) {
+            $src = SeoLinkerModel::getOne(['url' => $ln->from_url]);
+            $ln->from_id = $src->id ?? null;
+        }
+
         Design::assign('page', $page);
         Design::assign('links', $links);
+        Design::assign('links_in', $links_in);
 
         return $this->getTemplatePath('templates/page.tpl');
     }

--- a/hugashop/crm/Extensions/SeoLinker/templates/page.tpl
+++ b/hugashop/crm/Extensions/SeoLinker/templates/page.tpl
@@ -8,6 +8,9 @@
         <h1>{$page->url}</h1>
     </div>
     <div id="main_list">
+        <div class="row gx-5">
+            <div class="col-lg-6 layer">
+                <h2>Исходящие ссылки</h2>
         {if $links}
             <div class="list">
                 {foreach $links as $ln}
@@ -26,5 +29,32 @@
         {else}
             Нет ссылок
         {/if}
+
+            </div>
+            <div class="col-lg-6 layer">
+                <h2>Входящие внутренние ссылки</h2>
+                {if $links_in}
+                    <div class="list">
+                        {foreach $links_in as $ln}
+                            <div class="list_row">
+                                <div class="row col">
+                                    <div class="col-12 col-lg-8 text-break">
+                                        {if $ln->from_id}
+                                            <a href="/admin/extension/{$extension->module}/page/{$ln->from_id}">
+                                                {$ln->from_url}
+                                            </a>
+                                        {else}
+                                            {$ln->from_url}
+                                        {/if}
+                                    </div>
+                                </div>
+                            </div>
+                        {/foreach}
+                    </div>
+                {else}
+                    Нет ссылок
+                {/if}
+            </div>
+        </div>
     </div>
 {/block}


### PR DESCRIPTION
## Summary
- show inbound internal links in a second column on the SeoLinker page view
- update `SeoLinker` extension version

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686065ecd28c8326a11ce1782958405f