### PR TITLE
Add warehouse stock tracking

### DIFF
--- a/hugashop/crm/Models/Warehouse/WarehouseMove.php
+++ b/hugashop/crm/Models/Warehouse/WarehouseMove.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.3
+ * @version 2.4
  *
  * Работаем со складом, закупками, поставками, списанием
  *
@@ -17,6 +17,7 @@ use HugaShop\Models\Helper;
 use HugaShop\Models\BaseModel;
 use HugaShop\Models\User\User;
 use HugaShop\Models\Product\Product;
+use HugaShop\Models\Warehouse\WarehouseProduct;
 use Illuminate\Support\Collection;
 use HugaShop\Models\Finance\FinancePayment;
 use HugaShop\Models\Finance\FinancePaymentContractor;
@@ -247,6 +248,7 @@ class WarehouseMove extends BaseModel
             foreach (WarehousePurchase::where('move_id', $movement->id)->get() as $purchase) {
                 if ($purchase->amount) {
                     Product::updateStock($purchase->product_id, $factor * $purchase->amount);
+                    WarehouseProduct::changeAmount($purchase->product_id, $movement->place_id, $factor * $purchase->amount);
                 }
             }
             $movement->update(['closed' => 1]);
@@ -275,6 +277,7 @@ class WarehouseMove extends BaseModel
             foreach (WarehousePurchase::where('move_id', $movement->id)->get() as $purchase) {
                 if ($purchase->amount) {
                     Product::updateStock($purchase->product_id, - ($factor) * $purchase->amount);
+                    WarehouseProduct::changeAmount($purchase->product_id, $movement->place_id, -($factor) * $purchase->amount);
                 }
             }
             $movement->update(['closed' => 0]);

--- a/hugashop/crm/Models/Warehouse/WarehouseProduct.php
+++ b/hugashop/crm/Models/Warehouse/WarehouseProduct.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.4
+ * @version 1.5
  *
  */
 
@@ -32,5 +32,26 @@ class WarehouseProduct extends BaseModel
             ['product_id' => $purchase['product_id'], 'place_id' => $purchase['place_id']],
             $purchase
         );
+    }
+
+    /**
+     * Increment or decrement stock count for a product on specific place
+     */
+    public static function changeAmount(int $product_id, int $place_id, int $amount): void
+    {
+        if ($amount === 0) {
+            return;
+        }
+
+        $item = self::firstOrCreate([
+            'product_id' => $product_id,
+            'place_id'   => $place_id,
+        ], [
+            'move_id'    => 0,
+            'cost_price' => 0,
+            'amount'     => 0,
+        ]);
+
+        $item->increment('amount', $amount);
     }
 }

--- a/hugashop/crm/Models/Warehouse/WarehousePurchase.php
+++ b/hugashop/crm/Models/Warehouse/WarehousePurchase.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  * 
  * @author Andri Huga
- * @version 2.7
+ * @version 2.8
  * 
  */
 
@@ -12,6 +12,7 @@ namespace HugaShop\Models\Warehouse;
 
 use HugaShop\Models\BaseModel;
 use HugaShop\Models\Product\Product;
+use HugaShop\Models\Warehouse\WarehouseProduct;
 use Illuminate\Support\Collection;
 
 class WarehousePurchase extends BaseModel
@@ -95,14 +96,17 @@ class WarehousePurchase extends BaseModel
                 // забираем со старого варианта
                 if ($old->product_id) {
                     Product::updateStock($old->product_id, -$factor * $old->amount);
+                    WarehouseProduct::changeAmount($old->product_id, $movement->place_id, -$factor * $old->amount);
                 }
 
                 // добавляем в новый вариант
                 Product::updateStock($purchase->product_id, $factor * $purchase->amount);
+                WarehouseProduct::changeAmount($purchase->product_id, $movement->place_id, $factor * $purchase->amount);
 
                 // обновляем склад с новым значением поставки
             } elseif (!empty($purchase->product_id)) {
                 Product::updateStock($old->product_id, -$factor * ($old->amount - $purchase->amount));
+                WarehouseProduct::changeAmount($old->product_id, $movement->place_id, -$factor * ($old->amount - $purchase->amount));
             }
         }
 
@@ -145,6 +149,7 @@ class WarehousePurchase extends BaseModel
         if ($movement->closed && !empty($purchase->amount)) {
             $factor = in_array($movement->status, [3, 4]) ? -1 : 1;
             Product::updateStock($product->id, $factor * $purchase->amount);
+            WarehouseProduct::changeAmount($product->id, $movement->place_id, $factor * $purchase->amount);
         }
 
         return WarehousePurchase::create($purchase);
@@ -174,6 +179,7 @@ class WarehousePurchase extends BaseModel
             // Если поставка, отнимаем со склада
             $factor = in_array($movement->status, [3, 4]) ? 1 : -1;
             Product::updateStock($purchase->product_id, $factor * $purchase->amount);
+            WarehouseProduct::changeAmount($purchase->product_id, $movement->place_id, $factor * $purchase->amount);
         }
 
         return self::deleteOne($id) > 0;

--- a/src/Controller/Admin/Warehouse/MoveController.php
+++ b/src/Controller/Admin/Warehouse/MoveController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 4.0
+ * @version 4.1
  *
  */
 


### PR DESCRIPTION
## Summary
- track product amounts for each warehouse place
- adjust stock counts in move close/open logic
- update purchase operations to maintain per-place stock

## Testing
- `php -v` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686079181f388326bdccd8bbeeba6b88