### PR TITLE
Implement totals for moves via relations

### DIFF
--- a/hugashop/crm/Models/Warehouse/WarehouseMove.php
+++ b/hugashop/crm/Models/Warehouse/WarehouseMove.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.5
+ * @version 2.7
  *
  * Работаем со складом, закупками, поставками, списанием
  *
@@ -129,6 +129,42 @@ class WarehouseMove extends BaseModel
     public static function countMovements(array $filter = []): int
     {
         return self::getMovements($filter, count: true);
+    }
+
+
+    /**
+     * Подсчитываем общую себестоимость, розничную стоимость и количество
+     * товаров в выбранных перемещениях
+     * @param array $filter
+     * @return object
+     */
+    public static function getMovementsTotals(array $filter = []): object
+    {
+        $query = self::query();
+
+        if (isset($filter['status'])) {
+            $query->where('status', $filter['status']);
+        } else {
+            $query->whereNotIn('status', [3, 4]);
+        }
+
+        $movements = $query->with('purchases')->get();
+
+        $totals = [
+            'cost_price'     => 0.0,
+            'retail_price'   => 0.0,
+            'product_amount' => 0,
+        ];
+
+        foreach ($movements as $move) {
+            foreach ($move->purchases as $purchase) {
+                $totals['cost_price']   += $purchase->cost_price * $purchase->amount;
+                $totals['retail_price'] += $purchase->price * $purchase->amount;
+                $totals['product_amount'] += $purchase->amount;
+            }
+        }
+
+        return (object) $totals;
     }
 
 

--- a/src/Controller/Admin/Warehouse/MoveListController.php
+++ b/src/Controller/Admin/Warehouse/MoveListController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.2
+ * @version 2.5
  *
  */
 
@@ -63,13 +63,11 @@ class MoveListController extends BaseAdminController
         $total->retail_price = 0;
         $total->product_amount = 0;
 
-        if ($movements->isNotEmpty()) {
-
-            // TODO: сделай подсчет общей себестоимости всех выбранных поставок(cost_price) 
-            // Обзей розничной стоимости (retail_price)
-            // Кол-во единиц товара во всех выбранных поставках (product_amount)
-            // только для status=0 и status=1
-
+        if (in_array($filter['status'], [0, 1], true)) {
+            $totals = WarehouseMove::getMovementsTotals($filter);
+            $total->cost_price = $totals->cost_price;
+            $total->retail_price = $totals->retail_price;
+            $total->product_amount = $totals->product_amount;
         }
 
         Design::assign('total', $total);


### PR DESCRIPTION
## Summary
- query open moves with related purchases to calculate totals
- update controller and model version headers

## Testing
- `php -l src/Controller/Admin/Warehouse/MoveListController.php`
- `php -l hugashop/crm/Models/Warehouse/WarehouseMove.php`
- `apt-get install -y php-cli`

------
https://chatgpt.com/codex/tasks/task_e_6860aa16d5c88326817e8a56dc05bd06