### PR TITLE
Add product orders page

### DIFF
--- a/src/Controller/Admin/Product/ProductOrdersController.php
+++ b/src/Controller/Admin/Product/ProductOrdersController.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ *
+ * ProductOrdersAdmin
+ */
+
+namespace App\Controller\Admin\Product;
+
+use HugaShop\Services\Design;
+use App\Services\PaginationService;
+use HugaShop\Models\Order\Order;
+use HugaShop\Models\Product\Product;
+use App\Controller\BaseAdminController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class ProductOrdersController extends BaseAdminController
+{
+    #[Route('/admin/product/{id}/orders', requirements: ['id' => '\\d+'], name: 'ProductOrdersAdmin')]
+    public function index(int $id): Response
+    {
+        $this->checkAdminAccess('order');
+
+        if (!$product = Product::getProduct($id)) {
+            return $this->redirectToRoute('ProductListAdmin');
+        }
+
+        Design::assign('product', $product);
+
+        $this->assignOrders($product->id);
+
+        return $this->fetchResponse('product/product_orders.tpl');
+    }
+
+    /**
+     * Assign product orders to design
+     */
+    private function assignOrders(int $product_id): void
+    {
+        $filter = PaginationService::initFilter();
+        $filter['product_id'] = $product_id;
+
+        $orders_count = Order::getOrdersCount($filter);
+        $orders = Order::getOrders($filter, join: [
+            'delivery_method',
+            'payment_method',
+            'purchases',
+            'purchases.product',
+            'purchases.product.image',
+            'labels'
+        ]);
+
+        $paid_filter = ['paid' => 1, 'product_id' => $product_id];
+        $orders_paid_price = Order::getOrdersPrice($paid_filter);
+
+        Design::assign('pagination', PaginationService::getPagination($orders_count, $filter));
+        Design::assign('orders', $orders);
+        Design::assign('orders_count', $orders_count);
+        Design::assign('orders_paid_price', $orders_paid_price);
+    }
+}

--- a/src/Controller/Admin/Product/ProductPriceController.php
+++ b/src/Controller/Admin/Product/ProductPriceController.php
@@ -4,7 +4,7 @@
  * HugaShop - Selling anything
  *
  * @author Andri Huga
- * @version 2.9
+ * @version 3.0
  * 
  * ProductPriceAdmin
  *
@@ -104,40 +104,10 @@ class ProductPriceController extends BaseAdminController
 
             $product_variants = ProductVariant::getVariants($product->id, ['product', 'product.image']);
             Design::assign('product_variants', $product_variants);
-
-            $this->getProductOrders($product->id);
         }
 
         return $this->fetchResponse('product/product_price.tpl');
     }
 
 
-    /**
-     * Get all products order  
-     */
-    private function getProductOrders(int $product_id)
-    {
-        // Заказы с этим товаром
-        $filter = PaginationService::initFilter();
-        $filter['product_id'] = $product_id;
-
-        $orders_count = Order::getOrdersCount($filter);     # Кол-во заказов
-        $orders =       Order::getOrders($filter, join: [   # Выбираем заказы с этим товаром
-            'delivery_method',
-            'payment_method',
-            'purchases',
-            'purchases.product',
-            'purchases.product.image',
-            'labels'
-        ]);
-
-        $paid_filter = ['paid' => 1, 'product_id' => $product_id]; # только оплаченые
-        $orders_paid_price = Order::getOrdersPrice($paid_filter); # Выбираем общую сумму заказов
-
-        Design::assign('pagination', PaginationService::getPagination($orders_count, $filter));
-
-        Design::assign('orders', $orders);
-        Design::assign('orders_count', $orders_count);
-        Design::assign('orders_paid_price', $orders_paid_price);
-    }
 }

--- a/templates/admin/product/parts/submenu_part.tpl
+++ b/templates/admin/product/parts/submenu_part.tpl
@@ -8,11 +8,17 @@
 			</li>
 		{/if}
 
-		{if 'product_price'|user_access and $product->id}
-			<li class="{if $route == 'ProductPriceAdmin'}active{/if}">
-				<a href="/admin/product/{$product->id}/price">Цены</a>
-			</li>
-		{/if}
+                {if 'product_price'|user_access and $product->id}
+                        <li class="{if $route == 'ProductPriceAdmin'}active{/if}">
+                                <a href="/admin/product/{$product->id}/price">Цены</a>
+                        </li>
+                {/if}
+
+                {if 'order'|user_access and $product->id}
+                        <li class="{if $route == 'ProductOrdersAdmin'}active{/if}">
+                                <a href="/admin/product/{$product->id}/orders">Заказы</a>
+                        </li>
+                {/if}
 
 		{if $smarty.get.return}
 			<li class="back">

--- a/templates/admin/product/product_orders.tpl
+++ b/templates/admin/product/product_orders.tpl
@@ -1,0 +1,63 @@
+{extends 'wrapper/main.tpl'}
+{include 'product/parts/menu_part.tpl'}
+{include 'product/parts/submenu_part.tpl'}
+
+{if $product->id}
+        {$meta_title = $product->name}
+{/if}
+
+{block name=content}
+        <div class="row mt-5">
+                <div class="col-12 layer">
+                        <div class="header_top mt-3">
+                                <h1>
+                                        {if $orders_count > 0}{$orders_count}{else}Нет{/if} заказ{$orders_count|plural:'':'ов':'а'}
+                                        {if 'finance'|user_access AND $orders_paid_price->sum_total_price}
+                                                <span class="sum_total">оплаченных на сумму: {$orders_paid_price->sum_total_price|price_html|raw}
+                                                        <span class="sum_profit_price">{$orders_paid_price->sum_profit_price|price_html:profit|raw}</span>
+                                                </span>
+                                        {/if}
+                                </h1>
+                                <form class="export_btn" method="post" action="/admin/product_orders/export?product_id={$product->id}" target="_blank">
+                                        <input type="image" src="{'images/export_excel.png'|asset}" name="export" data-bs-toggle="tooltip" title="Экспортировать заказы с товаром" />
+                                </form>
+                        </div>
+                </div>
+
+                <div class="col-12">
+                        {include file='parts/pagination.tpl'}
+                        <div class="list">
+                                {foreach $orders as $order}
+                                        {include file='order/parts/order_item_part.tpl'}
+                                {/foreach}
+                        </div>
+                        {include file='parts/pagination.tpl'}
+                </div>
+        </div>
+{/block}
+
+{block name=body_script append}
+        <script type="module">
+                {literal}
+                        $(function() {
+                                $(".notice_block").each(function() {
+                                        let height = $(this).height();
+                                        let minimize_height = 60;
+                                        if (height > minimize_height && (height - minimize_height) > 40) {
+                                                $(this).addClass("minimizeble minimize");
+                                        }
+                                });
+                                $(".show_link_block a").click(function() {
+                                        if ($(this).closest("div.notice_block").hasClass("minimize")) {
+                                                $(this).closest("div.notice_block").removeClass("minimize");
+                                                $(this).text("скрыть ↑");
+                                        } else {
+                                                $(this).closest("div.notice_block").addClass("minimize");
+                                                $(this).text("раскрыть ↓");
+                                        }
+                                        return false;
+                                });
+                        });
+                {/literal}
+        </script>
+{/block}

--- a/templates/admin/product/product_price.tpl
+++ b/templates/admin/product/product_price.tpl
@@ -338,40 +338,6 @@
 	</form>
 
 
-	<!-- Заказы с товаром -->
-	<div class="row mt-5">
-		<div class="col-12 layer">
-			<div class="header_top mt-3">
-				<h1>
-					{if $orders_count > 0}{$orders_count}{else}Нет{/if} заказ{$orders_count|plural:'':'ов':'а'}
-					{if 'finance'|user_access AND $orders_paid_price->sum_total_price}
-						<span class="sum_total">оплаченых на сумму: {$orders_paid_price->sum_total_price|price_html|raw}
-							<span class="sum_profit_price">{$orders_paid_price->sum_profit_price|price_html:profit|raw}</span>
-						</span>
-					{/if}
-				</h1>
-				<form class="export_btn" method="post" action="/admin/product_orders/export?product_id={$product->id}"
-					target="_blank">
-					<input type="image" src="{'images/export_excel.png'|asset}" name="export" data-bs-toggle="tooltip"
-						title="Экспортировать заказы с товаром" />
-				</form>
-			</div>
-		</div>
-
-		<div class="col-12">
-
-			{include file='parts/pagination.tpl'}
-
-			<div class="list">
-				{foreach $orders as $order}
-					{include file='order/parts/order_item_part.tpl'}
-				{/foreach}
-			</div>
-
-			{include file='parts/pagination.tpl'}
-
-		</div>
-	</div>
 {/block}
 
 


### PR DESCRIPTION
## Summary
- make product price page no longer show orders
- add ProductOrdersAdmin controller and template
- link the new page in product submenu

## Testing
- `php -l src/Controller/Admin/Product/ProductPriceController.php`
- `php -l src/Controller/Admin/Product/ProductOrdersController.php`


------
https://chatgpt.com/codex/tasks/task_e_6862c555aecc83268fbd68c5e5cf55ab