### PR TITLE
Add product supply history page

### DIFF
--- a/hugashop/crm/Models/Warehouse/WarehousePurchase.php
+++ b/hugashop/crm/Models/Warehouse/WarehousePurchase.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  * 
  * @author Andri Huga
- * @version 2.8
+ * @version 2.9
  * 
  */
 
@@ -183,5 +183,62 @@ class WarehousePurchase extends BaseModel
         }
 
         return self::deleteOne($id) > 0;
+    }
+
+
+    /**
+     * Get purchases for specific product with optional join
+     */
+    public static function getProductPurchases(array $filter = [], array $join = [], bool $count = false): Collection|int
+    {
+        $query = self::query();
+
+        if (empty($filter['product_id'])) {
+            return $count ? 0 : collect();
+        }
+        $query->whereIn('product_id', (array) $filter['product_id']);
+
+        if (isset($filter['status'])) {
+            $query->whereHas('warehouse_move', function ($q) use ($filter) {
+                $q->where('status', $filter['status']);
+            });
+        }
+
+        if ($count) {
+            return $query->count();
+        }
+
+        $with = [];
+        if (in_array('warehouse_move', $join) || in_array('warehouse_move.place', $join)) {
+            $with[] = 'warehouse_move';
+            if (in_array('warehouse_move.place', $join)) {
+                $with[] = 'warehouse_move.place';
+            }
+        }
+        if (in_array('product', $join)) {
+            $with[] = 'product';
+            $with[] = 'product.image';
+        }
+        if ($with) {
+            $query->with($with);
+        }
+
+        $query->orderByDesc('id');
+
+        if (isset($filter['limit']) && $filter['limit'] !== 'all') {
+            $limit = max(1, (int) $filter['limit']);
+            $page = max(1, (int) ($filter['page'] ?? 1));
+            $query->skip(($page - 1) * $limit)->take($limit);
+        }
+
+        return $query->get();
+    }
+
+    /**
+     * Count product purchases
+     */
+    public static function countProductPurchases(array $filter = []): int
+    {
+        return self::getProductPurchases($filter, count: true);
     }
 }

--- a/src/Controller/Admin/Product/ProductMoveController.php
+++ b/src/Controller/Admin/Product/ProductMoveController.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ *
+ * ProductMoveAdmin
+ */
+
+namespace App\Controller\Admin\Product;
+
+use HugaShop\Services\Design;
+use App\Services\PaginationService;
+use HugaShop\Models\Product\Product;
+use App\Controller\BaseAdminController;
+use HugaShop\Models\Warehouse\WarehousePurchase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class ProductMoveController extends BaseAdminController
+{
+    #[Route('/admin/product/{id}/move', requirements: ['id' => '\\d+'], name: 'ProductMoveAdmin')]
+    public function index(int $id): Response
+    {
+        $this->checkAdminAccess('warehouse');
+
+        if (!$product = Product::getProduct($id)) {
+            return $this->redirectToRoute('ProductListAdmin');
+        }
+
+        $filter = PaginationService::initFilter();
+        $filter['product_id'] = $product->id;
+
+        $purchases_count = WarehousePurchase::countProductPurchases($filter);
+        $purchases = WarehousePurchase::getProductPurchases($filter, ['warehouse_move', 'warehouse_move.place']);
+
+        Design::assign('product', $product);
+        Design::assign('purchases', $purchases);
+        Design::assign('purchases_count', $purchases_count);
+        Design::assign('pagination', PaginationService::getPagination($purchases_count, $filter));
+
+        return $this->fetchResponse('product/product_move.tpl');
+    }
+}

--- a/templates/admin/product/parts/submenu_part.tpl
+++ b/templates/admin/product/parts/submenu_part.tpl
@@ -20,6 +20,12 @@
                         </li>
                 {/if}
 
+                {if 'warehouse'|user_access and $product->id}
+                        <li class="{if $route == 'ProductMoveAdmin'}active{/if}">
+                                <a href="/admin/product/{$product->id}/move">Поставки</a>
+                        </li>
+                {/if}
+
 		{if $smarty.get.return}
 			<li class="back">
 				<a class="out_link" href="{$smarty.get.return}">Назад</a>

--- a/templates/admin/product/product_move.tpl
+++ b/templates/admin/product/product_move.tpl
@@ -1,0 +1,44 @@
+{extends 'wrapper/main.tpl'}
+{include 'product/parts/menu_part.tpl'}
+{include 'product/parts/submenu_part.tpl'}
+
+{if $product->id}
+    {$meta_title = $product->name}
+{/if}
+
+{block name=content}
+    <div class="row">
+        <div class="col-12">
+            <div class="header_top mt-3">
+                <h1>
+                    {if $purchases_count}{$purchases_count}{else}Нет{/if} постав{$purchases_count|plural:'ка':'ок':'ки'}
+                </h1>
+            </div>
+        </div>
+        <div class="col-12">
+            {include file='parts/pagination.tpl'}
+            <div class="list">
+                {foreach $purchases as $purchase}
+                    <div class="list_row" item_id="{$purchase->id}">
+                        <div class="order_date">
+                            <a class="order_id" href="/admin/warehouse/movement/{$purchase->move_id}">#<span>{$purchase->move_id}</span></a>
+                            <div class="date">{$purchase->warehouse_move->date|date}</div>
+                        </div>
+                        <div class="col">
+                            <div class="row">
+                                <div class="col-12 col-md-6">
+                                    {$purchase->warehouse_move->place->name}
+                                </div>
+                                <div class="col-12 col-md-6 mt-3 mt-md-0">
+                                    <div class="order_price">{$purchase->amount} шт</div>
+                                    <div class="notice">{$purchase->warehouse_move->note|strip_tags}</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                {/foreach}
+            </div>
+            {include file='parts/pagination.tpl'}
+        </div>
+    </div>
+{/block}


### PR DESCRIPTION
## Summary
- add method to fetch product purchases from warehouse
- add admin controller and template for product supplies
- update submenu with 'Поставки' link

## Testing
- `php -l src/Controller/Admin/Product/ProductMoveController.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6862d037da988326bdb638f4908b9c0c