### PR TITLE
Prevent warehouse change after delivery

### DIFF
--- a/hugashop/crm/Models/Warehouse/WarehouseMove.php
+++ b/hugashop/crm/Models/Warehouse/WarehouseMove.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.9
+ * @version 3.0
  *
  * Работаем со складом, закупками, поставками, списанием
  *
@@ -198,6 +198,12 @@ class WarehouseMove extends BaseModel
         if (!empty($movement->awaiting_date)) {
             $movement->awaiting_date = Helper::dateConvert($movement->awaiting_date . ' 12:00', 'Y-m-d');
         }
+
+        $current = self::find(is_array($id) ? $id['id'] : $id);
+        if ($current && in_array($current->status, [2, 3]) && isset($movement->place_id)) {
+            unset($movement->place_id);
+        }
+
         $movement->modified = date('Y-m-d H:i:s');
 
         return self::updateOne($id, $movement);

--- a/src/Controller/Admin/Warehouse/MoveController.php
+++ b/src/Controller/Admin/Warehouse/MoveController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 4.2
+ * @version 4.3
  *
  */
 
@@ -193,6 +193,7 @@ class MoveController extends BaseAdminController
         if ((in_array('warehouse_add', User::authUser('permissions')) and empty($movement->status)) or in_array('warehouse_edit', User::authUser('permissions'))) {
             $can_edit = true;
         }
+        $can_change_place = $can_edit && !in_array($movement->status, [2, 3], true);
 
         $warehouse_places = WarehousePlace::getList(['enabled' => 1], 'position');
 
@@ -200,6 +201,7 @@ class MoveController extends BaseAdminController
             'movement'          => $movement,
             'total'             => $total,
             'can_edit'          => $can_edit,
+            'can_change_place'  => $can_change_place,
             'warehouse_places'  => $warehouse_places
         ]);
 

--- a/templates/admin/warehouse/move.tpl
+++ b/templates/admin/warehouse/move.tpl
@@ -84,7 +84,7 @@
 
 					<li class="wh_place">
 						<label class="col-form-label" for="place_id">Склад</label>
-						<select class="form-select" name="place_id" id="place_id" {if !$can_edit}disabled{/if}>
+                                                <select class="form-select" name="place_id" id="place_id" {if !$can_edit || !$can_change_place}disabled{/if}>
 							{foreach $warehouse_places as $place}
 								<option class="" value="{$place->id}" {if $movement->place_id == $place->id}selected{/if}>
 									{$place->name}</option>


### PR DESCRIPTION
## Summary
- restrict editing warehouse for delivered or written-off moves
- expose flag to template
- disable warehouse select in UI

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e00471388326be18a980375d70af