### PR TITLE
Display warehouse moves for product

### DIFF
--- a/hugashop/crm/Models/Warehouse/WarehouseMove.php
+++ b/hugashop/crm/Models/Warehouse/WarehouseMove.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.9
+ * @version 3.0
  *
  * Работаем со складом, закупками, поставками, списанием
  *
@@ -91,6 +91,12 @@ class WarehouseMove extends BaseModel
             $query->where('modified', '>', $filter['modified_since']);
         }
 
+        if (isset($filter['product_id'])) {
+            $query->whereHas('purchases', function ($q) use ($filter) {
+                $q->whereIn('product_id', (array) $filter['product_id']);
+            });
+        }
+
         if (!empty($filter['keyword'])) {
             $keywords = explode(' ', $filter['keyword']);
             foreach ($keywords as $word) {
@@ -144,6 +150,12 @@ class WarehouseMove extends BaseModel
 
         if (isset($filter['status'])) {
             $query->where('status', $filter['status']);
+        }
+
+        if (isset($filter['product_id'])) {
+            $query->whereHas('purchases', function ($q) use ($filter) {
+                $q->whereIn('product_id', (array) $filter['product_id']);
+            });
         }
 
         $movements = $query->with('purchases')->get();

--- a/src/Controller/Admin/Product/ProductMoveController.php
+++ b/src/Controller/Admin/Product/ProductMoveController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.0
+ * @version 1.1
  *
  * ProductMoveAdmin
  */
@@ -15,7 +15,8 @@ use HugaShop\Services\Design;
 use App\Services\PaginationService;
 use HugaShop\Models\Product\Product;
 use App\Controller\BaseAdminController;
-use HugaShop\Models\Warehouse\WarehousePurchase;
+use HugaShop\Models\Warehouse\WarehouseMove;
+use HugaShop\Services\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -32,14 +33,27 @@ class ProductMoveController extends BaseAdminController
 
         $filter = PaginationService::initFilter();
         $filter['product_id'] = $product->id;
+        $filter['status'] = Request::getInt('status');
 
-        $purchases_count = WarehousePurchase::countProductPurchases($filter);
-        $purchases = WarehousePurchase::getProductPurchases($filter, ['warehouse_move', 'warehouse_move.place']);
+        $keyword = Request::get('keyword', 'string');
+        if (!empty($keyword)) {
+            $filter['keyword'] = $keyword;
+            Design::assign('keyword', $keyword);
+        }
+
+        $movements = WarehouseMove::getMovements($filter, ['images', 'purchases', 'purchases.product', 'purchases.product.image']);
+        $movements_count = WarehouseMove::countMovements($filter);
+
+        if (in_array($filter['status'], [0, 1], true)) {
+            $total = WarehouseMove::getMovementsTotals($filter);
+            Design::assign('total', $total);
+        }
 
         Design::assign('product', $product);
-        Design::assign('purchases', $purchases);
-        Design::assign('purchases_count', $purchases_count);
-        Design::assign('pagination', PaginationService::getPagination($purchases_count, $filter));
+        Design::assign('movements', $movements);
+        Design::assign('movements_count', $movements_count);
+        Design::assign('status', $filter['status']);
+        Design::assign('pagination', PaginationService::getPagination($movements_count, $filter));
 
         return $this->fetchResponse('product/product_move.tpl');
     }

--- a/templates/admin/product/product_move.tpl
+++ b/templates/admin/product/product_move.tpl
@@ -7,38 +7,143 @@
 {/if}
 
 {block name=content}
-    <div class="row">
-        <div class="col-12">
-            <div class="header_top mt-3">
-                <h1>
-                    {if $purchases_count}{$purchases_count}{else}Нет{/if} постав{$purchases_count|plural:'ка':'ок':'ки'}
-                </h1>
+    {if $message_error}
+        <div class="message message_error">
+            <span class="text">{if $message_error=='error_closing'}Нехватка некоторых товаров на складе{else}{$message_error}{/if}</span>
+        </div>
+    {/if}
+
+    <div class="two_columns_list">
+        <div class="header_top">
+            <h1>
+                {if $status == 3}
+                    {if $movements_count}{$movements_count}{else}Нет{/if} списан{$movements_count|plural:'ие':'ий':'ия'}
+                {elseif $status == 4}
+                    {if $movements_count}{$movements_count}{else}Нет{/if} отмененн{$movements_count|plural:'ое':'ых':'ых'}
+                {elseif $status == 2}
+                    {if $movements_count}Поступило {$movements_count}{else}Нет{/if}
+                    постав{$movements_count|plural:'ка':'ок':'ки'}
+                {else}
+                    {if $movements_count}
+                        {if $status == 1}Ожидаем {elseif $status === 0}Новыe {else}Всего {/if}{$movements_count}
+                    {else}
+                        Нет
+                    {/if}
+                    постав{$movements_count|plural:'ка':'ок':'ки'}
+                    {if 'finance'|user_access AND !$total|empty AND $status !== null }
+                        <span class="sum_total">на сумму: {$total->cost_price|price_html|raw}
+                            <span class="sum_profit_price">{($total->retail_price - $total->cost_price)|price_html:profit|raw}</span>
+                        </span>
+                        <span class="sum_total"> ({$total->product_amount} единиц товара)</span>
+                    {/if}
+                {/if}
+            </h1>
+            {if 'warehouse_edit'|user_access OR 'warehouse_add'|user_access}
+                <a class="add" href="{'MoveNewAdmin'|urll}">Добавить перемещение товара</a>
+            {/if}
+        </div>
+
+        <div class="navbar-expand-lg" id="right_menu">
+            <div class="popup_menu_btn navbar-toggler" data-bs-toggle="offcanvas" data-bs-target="#filter_menu_block">
+                <span class="material-icons">menu</span>
+                <span class="popup_btn_text">Фильтр</span>
+            </div>
+
+            <div class="offcanvas offcanvas-start" id="filter_menu_block" tabindex="-1" aria-labelledby="offcanvasLabel">
+                <div class="offcanvas-header">
+                    <h5 class="offcanvas-title" id="offcanvasLabel"></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                </div>
+
+                <div class="offcanvas-body">
+                    <ul class="menu_list">
+                        <li {if $status === null}class="selected" {/if}><a href='{url status=null clear=true}'>Все поставки</a></li>
+                        <li {if $status === 0}class="selected" {/if}><a href='{url status='0' clear=true}'>Новые</a></li>
+                        <li {if $status == 1}class="selected" {/if}><a href='{url status=1 clear=true}'>Ожидаем</a></li>
+                        <li {if $status == 2}class="selected" {/if}><a href='{url status=2 clear=true}'>Поступило</a></li>
+                    </ul>
+
+                    <ul class='menu_list layer'>
+                        <li {if $status == 3}class="selected" {/if}><a href='{url status=3 clear=true}'>Списано</a></li>
+                        <li {if $status == 4}class="selected" {/if}><a href='{url status=4 clear=true}'>Отмена</a></li>
+                    </ul>
+                </div>
             </div>
         </div>
-        <div class="col-12">
-            {include file='parts/pagination.tpl'}
-            <div class="list">
-                {foreach $purchases as $purchase}
-                    <div class="list_row" item_id="{$purchase->id}">
-                        <div class="order_date">
-                            <a class="order_id" href="/admin/warehouse/movement/{$purchase->move_id}">#<span>{$purchase->move_id}</span></a>
-                            <div class="date">{$purchase->warehouse_move->date|date}</div>
-                        </div>
-                        <div class="col">
-                            <div class="row">
-                                <div class="col-12 col-md-6">
-                                    {$purchase->warehouse_move->place->name}
+
+        <div id="main_list">
+            {if $movements}
+                {include file='parts/pagination.tpl'}
+                <form method="post" class="list_form">
+                    {getCSRFInput}
+                    <div class="list">
+                        {foreach $movements as $movement}
+                            <div class="list_row {if $movement->status == 2}highlight{/if}" item_id="{$movement->id}">
+                                {if 'warehouse_edit'|user_access && $status === 4}
+                                    <div class="checkbox">
+                                        <input class="form-check-input" type="checkbox" name="check[]" value="{$movement->id}" />
+                                    </div>
+                                {/if}
+                                <div class="order_date">
+                                    <a class="order_id" href="{'MoveAdmin'|urll:[id => $movement->id]}"><span>{$movement->id}</span></a>
+                                    <div class="date">{$movement->date|date}</div>
                                 </div>
-                                <div class="col-12 col-md-6 mt-3 mt-md-0">
-                                    <div class="order_price">{$purchase->amount} шт</div>
-                                    <div class="notice">{$purchase->warehouse_move->note|strip_tags}</div>
+                                <div class="colrow">
+                                    <div class="col-12 col-md-6">
+                                        <div class="purchases">
+                                            {foreach $movement->purchases as $purchase}
+                                                <div class="image">
+                                                    <div class="amount">{$purchase->amount}</div>
+                                                    <img data-bs-toggle="tooltip" title="{$purchase->product_name}{if $purchase->variant_name}- {$purchase->variant_name}{/if}" src='{if $purchase->product->image->filename}{$purchase->product->image->filename|resize:60:60:c}{else}{'images/cargo.png'|asset}{/if}' />
+                                                </div>
+                                            {/foreach}
+                                        </div>
+                                    </div>
+                                    <div class="col-12 col-md-6 mt-3 mt-md-0">
+                                        {if $movement->status != 0}
+                                            <div class="order_price">{$movement->awaiting_date|date}</div>
+                                        {/if}
+                                        <div class="order_address">{$movement->note|strip_tags|nl2br|raw}</div>
+                                        {if 'warehouse_edit'|user_access AND $movement->note_logist}
+                                            <div class="notice_block">
+                                                <div class="notice_block_text">{$movement->note_logist|strip_tags|nl2br|raw}</div>
+                                                <div class="show_link_block"><a class="show_link" href="#">раскрыть ↓</a></div>
+                                            </div>
+                                        {/if}
+                                    </div>
+                                </div>
+                                <div class="icons flex-column">
+                                    {if $movement->status == 0}<i><img src="{'images/new.png'|asset}" data-bs-toggle="tooltip" title='Новый'></i>{/if}
+                                    {if $movement->status == 1}<i><img src="{'images/time.png'|asset}" data-bs-toggle="tooltip" title='Ожидаем'></i>{/if}
+                                    {if $movement->status == 2}<i><img src="{'images/tick.png'|asset}" data-bs-toggle="tooltip" title='Принят'></i>{/if}
+                                    {if $movement->status == 3 || $movement->status == 4}<i><img src="{'images/cross.png'|asset}" data-bs-toggle="tooltip" title='Списан'></i>{/if}
+                                    {if $movement->images->isNotEmpty()}<i><img src="{'images/clipboard.png'|asset}" data-bs-toggle="tooltip" title="Фотоотчет"></i>{/if}
                                 </div>
                             </div>
-                        </div>
+                        {/foreach}
                     </div>
-                {/foreach}
-            </div>
-            {include file='parts/pagination.tpl'}
+                    {if 'warehouse_edit'|user_access && $status === 4}
+                        <div id="action">
+                            <span id='check_all' class="dash_link">Выбрать все</span>
+                            <span id="select">
+                                <select class="form-select" name="action">
+                                    <option value="">Выбрать действие</option>
+                                    <option value="delete">Удалить выбранные поставки</option>
+                                </select>
+                            </span>
+                            <button class="btn btn-primary apply" id="apply_action" type="submit">Применить</button>
+                        </div>
+                    {/if}
+                </form>
+                {include file='parts/pagination.tpl'}
+            {/if}
         </div>
     </div>
+{/block}
+
+{block name=body_script append}
+    <script type="module">
+        import { initNoticeBlocks } from '{"js/common.js"|asset}';
+        $(function() { initNoticeBlocks(); });
+    </script>
 {/block}


### PR DESCRIPTION
## Summary
- filter warehouse moves by product ID
- show filtered moves in admin product page
- use updated template layout for product moves

## Testing
- `php -l src/Controller/Admin/Product/ProductMoveController.php`
- `php -l hugashop/crm/Models/Warehouse/WarehouseMove.php`
- `php composer.phar validate --no-interaction`


------
https://chatgpt.com/codex/tasks/task_e_6862e0de42208326b01a33ec7044bdba