### PR TITLE
Add spelled-out month support for date modifier

### DIFF
--- a/hugashop/crm/Services/Helper.php
+++ b/hugashop/crm/Services/Helper.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 3.2
+ * @version 3.3
  *
  */
 
@@ -16,6 +16,7 @@ use Illuminate\Support\Str;
 use Jenssegers\Agent\Agent;
 use HugaShop\Models\Settings;
 use HugaShop\Services\Request;
+use HugaShop\Services\Design;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
@@ -105,8 +106,24 @@ class Helper
         if (empty($date)) {
             $date = date("Y-m-d");
         }
+
         $date = new \DateTime($date);
         $date->setTimeZone(new \DateTimeZone(Settings::getParam('timezone')));
+
+        if ($format === 'm') {
+            $locale = Design::$Translator?->getLocale() ?? 'ru_RU';
+            $formatter = new \IntlDateFormatter(
+                $locale,
+                \IntlDateFormatter::FULL,
+                \IntlDateFormatter::NONE,
+                Settings::getParam('timezone'),
+                \IntlDateFormatter::GREGORIAN,
+                'd MMMM yyyy'
+            );
+
+            return $formatter->format($date);
+        }
+
         return $date->format(empty($format) ? Settings::getParam('date_format') : $format);
     }
 


### PR DESCRIPTION
## Summary
- upgrade Helper service version
- allow date format flag `m` for month name output

## Testing
- `node -v`
- `php composer.phar validate --no-check-all --strict` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e1945cfc8326b39b71d5c43069bf