### PR TITLE
Fix mailing list type filter

### DIFF
--- a/src/Controller/Admin/User/MailingListController.php
+++ b/src/Controller/Admin/User/MailingListController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.2
+ * @version 2.3
  *
  */
 
@@ -42,6 +42,15 @@ class MailingListController extends BaseAdminController
         }
 
         $filter = PaginationService::initFilter();
+
+        // Фильтр по типу отправки
+        $type = Request::get('type', 'string');
+        if (!empty($type)) {
+            $filter['type'] = $type;
+            Design::assign('type', $type);
+        } else {
+            Design::assign('type', null);
+        }
 
         $mailing_list = UserMailing::getList($filter, order: ['id', 'DESC'], join: ['user', 'notifier']);
         $mailing_count = UserMailing::getCount($filter);


### PR DESCRIPTION
## Summary
- enable filtering mailing list by message type

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f33548148326b7276950251bb7ab