### PR TITLE
Fix status null error in movement view

### DIFF
--- a/src/Controller/Admin/Warehouse/MoveController.php
+++ b/src/Controller/Admin/Warehouse/MoveController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 4.3
+ * @version 4.4
  *
  */
 
@@ -36,10 +36,13 @@ class MoveController extends BaseAdminController
         $total->purchases = 0;
         $payments = [];
 
+        $movement = Request::getDataAcces(WarehouseMove::getFields());
+
+
 
         #### Update
         ###########
-        if (!empty($movement = Request::getDataAcces(WarehouseMove::getFields()))) {
+        if (!empty($movement)) {
 
             // Создаем новую поставку/списание
             if (empty($movement->id)) {
@@ -186,6 +189,11 @@ class MoveController extends BaseAdminController
             if (!empty($movement->manager_id)) {
                 $movement->manager = User::getUser($movement->manager_id);
             }
+        }
+
+        if (empty($movement)) {
+            $movement = new \stdClass();
+            $movement->status = 0;
         }
 
         //  Определяем возможность редактировать


### PR DESCRIPTION
## Summary
- initialize `$movement` with request data and provide fallback object
- guard against null movement when checking edit and place change
- bump version to 4.4

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f23a8ba083269d60d8456b9c94d0