### PR TITLE
Add visibility toggle for product images

### DIFF
--- a/assets/admin/css/style.css
+++ b/assets/admin/css/style.css
@@ -1029,15 +1029,36 @@ select.multiple_categories option {
 }
 
 .images ul li i.delete {
-	top: 10px;
-	font-size: 1.5rem;
-	right: 11px;
-	position: absolute;
-	visibility: hidden;
+        top: 10px;
+        font-size: 1.5rem;
+        right: 11px;
+        position: absolute;
+        visibility: hidden;
+}
+
+.images ul li .image_icons {
+        top: 5px;
+        right: 5px;
+        position: absolute;
+        display: flex;
+        visibility: hidden;
+}
+
+.images ul li .image_icons i {
+        font-size: 1.5rem;
+        margin-left: 5px;
 }
 
 .images ul li:hover i.delete {
-	visibility: visible;
+        visibility: visible;
+}
+
+.images ul li:hover .image_icons {
+        visibility: visible;
+}
+
+.images ul li.visible_off {
+        opacity: 0.4;
 }
 
 .images .dropZone {

--- a/hugashop/crm/Extensions/FacebookCommerce/Models/FeedGenerator.php
+++ b/hugashop/crm/Extensions/FacebookCommerce/Models/FeedGenerator.php
@@ -151,7 +151,7 @@ class FeedGenerator
                 // Additional images
                 // Links to up to 20 additional images of your item, separated by a comma (,), semicolon (;), space ( ) or vertical bar (|).
                 // Follow the same image specifications as image_link.
-                $images = Image::getImages($product_raw->id, 'product');
+                $images = Image::getImages($product_raw->id, 'product', true);
                 $images = $images->slice(1)->values();
                 if ($images->isNotEmpty()) {
                     $product['additional_image_link'] = $images->map(function ($image) {

--- a/hugashop/crm/Extensions/GoogleMerchant/Models/FeedGenerator.php
+++ b/hugashop/crm/Extensions/GoogleMerchant/Models/FeedGenerator.php
@@ -110,7 +110,7 @@ class FeedGenerator
                 $product->image_link = Image::getImageURL($product_raw->image->filename, 1080, 1080);
 
                 // Обработка дополнительных фотографий
-                $images = Image::getImages($product_raw->id, 'product');
+                $images = Image::getImages($product_raw->id, 'product', true);
                 $images = $images->slice(1)->values();
                 if ($images->isNotEmpty()) {
                     $product->additional_image_link = $images->map(function ($image) {

--- a/hugashop/crm/Extensions/YandexMerchant/Models/FeedGenerator.php
+++ b/hugashop/crm/Extensions/YandexMerchant/Models/FeedGenerator.php
@@ -158,7 +158,7 @@ class FeedGenerator
 
                 // Добавляйте не больше 20 фотографий для одного товара.
                 // На фотографиях может использоваться водяной знак и иная информация о товаре
-                $images = Image::getImages($raw_product->id, 'product');
+                $images = Image::getImages($raw_product->id, 'product', true);
                 if ($images->isNotEmpty()) {
                     foreach ($images as $img) {
                         $resp_xml .= '<picture>' . Image::getImageURL($img->filename, 1080, 1080, 'w') . '</picture>';

--- a/hugashop/crm/Models/Image.php
+++ b/hugashop/crm/Models/Image.php
@@ -29,6 +29,7 @@ class Image extends BaseModel
         'entity_id' =>          ['type' => 'int'],
         'entity_name' =>        ['type' => 'varchar',       'lenght' => 25],
         'filename' =>           ['type' => 'varchar'],
+        'visible' =>            ['type' => 'tinyint',       'def' => 1],
         'position' =>           ['type' => 'created',       'def' => 0],
         'created' =>            ['type' => 'varchar',       'def' => 'CURRENT_TIMESTAMP']
     ];
@@ -59,24 +60,35 @@ class Image extends BaseModel
         }
 
         // Порядок основных изображений
+        $images_visible = Request::post($post_name . '_visible', 'array') ?: [];
         foreach ($images as $position => $im_id) {
-            self::updateOne($im_id, ['position' => $position]);
+            $visible = isset($images_visible[$im_id]) ? intval($images_visible[$im_id]) : 1;
+            self::updateOne($im_id, ['position' => $position, 'visible' => $visible]);
         }
 
         // Загрузка основных изображений из интернета и drag-n-drop файлов
         if ($urls = Request::post($post_name . '_urls')) {
+            $urls_visible = Request::post($post_name . '_urls_visible', 'array') ?: [];
             $dropped_images = Request::files('dropped_' . $post_name);
-            foreach ($urls as $url) {
+            foreach ($urls as $index => $url) {
                 // Если не пустой адрес и файл не локальный
                 if (!empty($url) && $url !== 'http://' && str_contains($url, '/')) {
-                    self::addImage($entity_id, $entity_name, $url);
+                    $new_id = self::addImage($entity_id, $entity_name, $url);
+                    if ($new_id) {
+                        $visible = isset($urls_visible[$index]) ? intval($urls_visible[$index]) : 1;
+                        self::updateOne($new_id, ['visible' => $visible]);
+                    }
                 } elseif ($dropped_images) {
                     $key = array_search($url, $dropped_images['name'], true);
                     if ($key !== false) {
                         // Move and Resize
                         $image_name = self::uploadImage($dropped_images['tmp_name'][$key], $dropped_images['name'][$key]);
                         if ($image_name) {
-                            self::addImage($entity_id, $entity_name, (string) $image_name);
+                            $new_id = self::addImage($entity_id, $entity_name, (string) $image_name);
+                            if ($new_id) {
+                                $visible = isset($urls_visible[$index]) ? intval($urls_visible[$index]) : 1;
+                                self::updateOne($new_id, ['visible' => $visible]);
+                            }
                         }
                     }
                 }
@@ -90,9 +102,13 @@ class Image extends BaseModel
      * @param int|array $entity_id
      * @param string $entity_name - product
      */
-    public static function getImages(int|array $entity_id, string $entity_name)
+    public static function getImages(int|array $entity_id, string $entity_name, bool $public = false)
     {
-        return self::getList(filter: ['entity_id' => $entity_id, 'entity_name' => $entity_name], order: 'position');
+        $filter = ['entity_id' => $entity_id, 'entity_name' => $entity_name];
+        if ($public) {
+            $filter['visible'] = 1;
+        }
+        return self::getList(filter: $filter, order: 'position');
     }
 
 

--- a/src/Controller/Admin/Ajax/Export/ProductExport.php
+++ b/src/Controller/Admin/Ajax/Export/ProductExport.php
@@ -117,7 +117,7 @@ class ProductExport extends BaseAdminController
 
 
         // Изображения товаров
-        $images = Image::getImages(array_keys($products), 'product');
+        $images = Image::getImages(array_keys($products), 'product', true);
 
         foreach ($images as $image) {
 

--- a/src/Controller/Front/ProductController.php
+++ b/src/Controller/Front/ProductController.php
@@ -53,6 +53,13 @@ class ProductController extends BaseFrontController
             'features'
         ]);
 
+        if ($product) {
+            $product->images = $product->images->filter(fn($i) => $i->visible);
+            if ($product->image && !$product->image->visible) {
+                $product->image = $product->images->first();
+            }
+        }
+
         if (empty($product)) {
             throw $this->createNotFoundException('Product does not found'); # 404
         }

--- a/templates/admin/parts/images_upload_init.tpl
+++ b/templates/admin/parts/images_upload_init.tpl
@@ -19,6 +19,20 @@
                 return false;
             });
 
+            // Показать/скрыть изображение
+            $(".images").on('click', 'i.enable.visibility', function() {
+                let li = $(this).closest('li');
+                let input = li.find("input[name*='_visible']");
+                let state = input.val() == '1' ? '0' : '1';
+                input.val(state);
+                if (state == '0') {
+                    li.addClass('visible_off');
+                } else {
+                    li.removeClass('visible_off');
+                }
+                return false;
+            });
+
             // Загрузить изображение с компьютера
             $('.upload_image').click(function() {
                 let name = $(this).closest('.images').attr('id');
@@ -78,13 +92,15 @@
 
                             // Render thumbnail.
                             $("<li class='wizard'>" +
-                                "<i class='delete material-icons' title='Удалить'>cancel</i>" +
+                                "<div class='image_icons'>" +
+                                "<i class='enable material-icons visibility' title='Показать'></i>" +
+                                "<i class='delete material-icons' title='Удалить'>cancel</i></div>" +
                                 "<a href='" + e.target.result +
                                 "' class='zoom' data-fancybox='images_content'>" +
                                 "<img onerror='$(this).closest(\"li\").remove();' src='" +
                                 e.target.result + "' />" +
                                 "<input name=" + name + "_urls[] type='hidden' value='" +
-                                theFile.name + "'/></a></li>").appendTo('#' + name + ' ul');
+                                theFile.name + "'/><input name=" + name + "_urls_visible[] type='hidden' value='1'/></a></li>").appendTo('#' + name + ' ul');
 
                             let temp_input = dropInput.clone().show();
 

--- a/templates/admin/product/product.tpl
+++ b/templates/admin/product/product.tpl
@@ -114,17 +114,21 @@
 			<div id="images" class="col-lg-6 layer images">
 				<h2>Изображения товара</h2>
 				<ul>
-					{foreach $product->images as $image}
-						<li>
-							<i class="delete material-icons" data-bs-toggle="tooltip" title="Удалить">cancel</i>
-							<a href="{$image->filename|resize:1080:1080:w}" class="zoom" data-fancybox="product_images"
-								data-caption="{$product->name}">
-								<img loading="lazy" src="{$image->filename|resize:220:220}" />
-							</a>
-							<input type="hidden" name="images[]" value="{$image->id}" />
-						</li>
-					{/foreach}
-				</ul>
+                                        {foreach $product->images as $image}
+                                                <li class="{if !$image->visible}visible_off{/if}">
+                                                        <div class="image_icons">
+                                                                <i class="enable material-icons visibility" title="Показать"></i>
+                                                                <i class="delete material-icons" data-bs-toggle="tooltip" title="Удалить">cancel</i>
+                                                        </div>
+                                                        <a href="{$image->filename|resize:1080:1080:w}" class="zoom" data-fancybox="product_images"
+                                                                data-caption="{$product->name}">
+                                                                <img loading="lazy" src="{$image->filename|resize:220:220}" />
+                                                        </a>
+                                                        <input type="hidden" name="images[]" value="{$image->id}" />
+                                                        <input type="hidden" name="images_visible[{$image->id}]" value="{$image->visible}" />
+                                                </li>
+                                        {/foreach}
+                                </ul>
 
 				<div class="dropZone">
 					<input type="file" name="dropped_images[]" multiple class="dropInput" />
@@ -203,17 +207,21 @@
 			<div id="images_content" class="col-12 layer images">
 				<h2>Картинки описания</h2>
 				<ul>
-					{foreach $product->images_content as $image}
-						<li>
-							<i class="delete material-icons" data-bs-toggle="tooltip" title="Удалить">cancel</i>
-							<a href="{$image->filename|resize:1080:1080:w}" class="zoom" data-fancybox="images_content"
-								data-caption="{$product->name}">
-								<img loading="lazy" src="{$image->filename|resize:220:220}" />
-							</a>
-							<input type="hidden" name="images_content[]" value="{$image->id}" />
-						</li>
-					{/foreach}
-				</ul>
+                                        {foreach $product->images_content as $image}
+                                                <li class="{if !$image->visible}visible_off{/if}">
+                                                        <div class="image_icons">
+                                                                <i class="enable material-icons visibility" title="Показать"></i>
+                                                                <i class="delete material-icons" data-bs-toggle="tooltip" title="Удалить">cancel</i>
+                                                        </div>
+                                                        <a href="{$image->filename|resize:1080:1080:w}" class="zoom" data-fancybox="images_content"
+                                                                data-caption="{$product->name}">
+                                                                <img loading="lazy" src="{$image->filename|resize:220:220}" />
+                                                        </a>
+                                                        <input type="hidden" name="images_content[]" value="{$image->id}" />
+                                                        <input type="hidden" name="images_content_visible[{$image->id}]" value="{$image->visible}" />
+                                                </li>
+                                        {/foreach}
+                                </ul>
 
 				<div class="dropZone">
 					<input type="file" name="dropped_images_content[]" multiple class="dropInput" />


### PR DESCRIPTION
## Summary
- store image visibility in `content_image` table
- keep position and visibility when saving images
- filter invisible images on product page
- export only visible images
- let admins toggle visibility in product editor
- style new image icons

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f114c74483269f4424d34c05ad8f