### PR TITLE
Refactor checkbox_line markup

### DIFF
--- a/hugashop/crm/Extensions/InfoBlock/templates/block.tpl
+++ b/hugashop/crm/Extensions/InfoBlock/templates/block.tpl
@@ -18,13 +18,13 @@
 
 			<div class="col-12">
 				<div class="over_name">
-					<div class="checkbox_line">
-						<div class="form-check">
-							<input class="form-check-input" name="enabled" value="1" type="checkbox" id="enabled"
-								{if $block->enabled}checked{/if} />
-							<label class="form-check-label" for="enabled">Активна</label>
-						</div>
-					</div>
+                                        <div class="checkbox_line">
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="enabled" value="1" type="checkbox" role="switch" id="enabled"
+                                                                {if $block->enabled}checked{/if} />
+                                                        <label class="form-check-label" for="enabled">Активна</label>
+                                                </div>
+                                        </div>
 				</div>
 
 				<div class="name_row">

--- a/hugashop/crm/Extensions/RedirectUrl/templates/link.tpl
+++ b/hugashop/crm/Extensions/RedirectUrl/templates/link.tpl
@@ -17,8 +17,8 @@
             <div class="col-12">
                 <div class="over_name">
                     <div class="checkbox_line">
-                        <div class="form-check">
-                            <input class="form-check-input" name="enabled" value="1" type="checkbox" id="enabled"
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" name="enabled" value="1" type="checkbox" role="switch" id="enabled"
                                 {if $link->enabled}checked{/if} />
                             <label class="form-check-label" for="enabled">Активна</label>
                         </div>

--- a/hugashop/crm/Extensions/SeoPage/templates/page.tpl
+++ b/hugashop/crm/Extensions/SeoPage/templates/page.tpl
@@ -18,13 +18,13 @@
 
 			<div class="col-12">
 				<div class="over_name">
-					<div class="checkbox_line">
-						<div class="form-check">
-							<input class="form-check-input" name="enabled" value="1" type="checkbox" id="enabled"
-								{if $page->enabled}checked{/if} />
-							<label class="form-check-label" for="enabled">Активна</label>
-						</div>
-					</div>
+                                        <div class="checkbox_line">
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="enabled" value="1" type="checkbox" role="switch" id="enabled"
+                                                                {if $page->enabled}checked{/if} />
+                                                        <label class="form-check-label" for="enabled">Активна</label>
+                                                </div>
+                                        </div>
 
 					{if $page->url}
 						<a class="out_link" target="_self" href="{$config->root_url}/{$page->url}">

--- a/templates/admin/content/page.tpl
+++ b/templates/admin/content/page.tpl
@@ -21,16 +21,16 @@
 			<div class="col-12">
 				<div class="over_name">
 					<div class="checkbox_line">
-						<div class="form-check">
-							<input class="form-check-input" name="visible" value="1" type="checkbox" id="visible"
-								{if $page->visible}checked{/if} />
-							<label class="form-check-label" for="visible">Активна</label>
-						</div>
-						<div class="form-check">
-							<input class="form-check-input" name="menu" value="1" type="checkbox" id="menu"
-								{if $page->menu}checked{/if} />
-							<label class="form-check-label" for="menu">Меню</label>
-						</div>
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="visible" value="1" type="checkbox" role="switch" id="visible"
+                                                                {if $page->visible}checked{/if} />
+                                                        <label class="form-check-label" for="visible">Активна</label>
+                                                </div>
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="menu" value="1" type="checkbox" role="switch" id="menu"
+                                                                {if $page->menu}checked{/if} />
+                                                        <label class="form-check-label" for="menu">Меню</label>
+                                                </div>
 					</div>
 
 					{if $page->url}

--- a/templates/admin/content/post.tpl
+++ b/templates/admin/content/post.tpl
@@ -20,13 +20,13 @@
 
 			<div class="col-12">
 				<div class="over_name">
-					<div class=checkbox_line>
-						<div class="form-check">
-							<input class="form-check-input" name="visible" value="1" type="checkbox" id="active_checkbox"
-								{if $post->visible}checked{/if} />
-							<label class="form-check-label" for="active_checkbox">Активна</label>
-						</div>
-					</div>
+                                        <div class="checkbox_line">
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="visible" value="1" type="checkbox" role="switch" id="active_checkbox"
+                                                                {if $post->visible}checked{/if} />
+                                                        <label class="form-check-label" for="active_checkbox">Активна</label>
+                                                </div>
+                                        </div>
 					<a class="out_link" target="_self" href="{$config->root_url}/blog/{$post->url}">Открыть статью на
 						сайте</a>
 				</div>

--- a/templates/admin/finance/purse.tpl
+++ b/templates/admin/finance/purse.tpl
@@ -19,11 +19,11 @@
 			<div class="col-12">
 				<div class="over_name">
 					<div class="checkbox_line">
-						<div class="form-check">
-							<input class="form-check-input" name="enabled" value='1' type="checkbox" id="active_checkbox"
-								{if $purse->enabled}checked{/if} />
-							<label class="form-check-label" for="active_checkbox">Активен</label>
-						</div>
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="enabled" value='1' type="checkbox" role="switch" id="active_checkbox"
+                                                                {if $purse->enabled}checked{/if} />
+                                                        <label class="form-check-label" for="active_checkbox">Активен</label>
+                                                </div>
 					</div>
 				</div>
 				<div class="name_row">

--- a/templates/admin/order/delivery.tpl
+++ b/templates/admin/order/delivery.tpl
@@ -21,16 +21,16 @@
 			<div class="col-12">
 				<div class="over_name">
 					<div class="checkbox_line">
-						<div class="form-check">
-							<input class="form-check-input" name="enabled" value="1" type="checkbox" id="active_checkbox"
-								{if $delivery->enabled}checked{/if} />
-							<label class="form-check-label" for="active_checkbox">Показывать меннеджеру</label>
-						</div>
-						<div class="form-check">
-							<input class="form-check-input" name="enabled_public" value="1" type="checkbox"
-								id="enabled_public" {if $delivery->enabled_public}checked{/if} />
-							<label class="form-check-label" for="enabled_public">Показывать клиенту при заказе</label>
-						</div>
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="enabled" value="1" type="checkbox" role="switch" id="active_checkbox"
+                                                                {if $delivery->enabled}checked{/if} />
+                                                        <label class="form-check-label" for="active_checkbox">Показывать меннеджеру</label>
+                                                </div>
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="enabled_public" value="1" type="checkbox" role="switch"
+                                                                id="enabled_public" {if $delivery->enabled_public}checked{/if} />
+                                                        <label class="form-check-label" for="enabled_public">Показывать клиенту при заказе</label>
+                                                </div>
 					</div>
 				</div>
 

--- a/templates/admin/order/label.tpl
+++ b/templates/admin/order/label.tpl
@@ -19,16 +19,16 @@
 			<div class="col-12">
 				<div class="over_name">
 					<div class="checkbox_line">
-						<div class="form-check">
-							<input class="form-check-input" name="enabled" value="1" type="checkbox" id="active_checkbox"
-								{if $label->enabled}checked{/if} />
-							<label class="form-check-label" for="active_checkbox">Активен</label>
-						</div>
-						<div class="form-check">
-							<input class="form-check-input" name="in_filter" value="1" type=checkbox id="in_filter_checkbox"
-								{if $label->in_filter}checked{/if} />
-							<label class="form-check-label" for="in_filter_checkbox">Использовать в фильтре заказов</label>
-						</div>
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="enabled" value="1" type="checkbox" role="switch" id="active_checkbox"
+                                                                {if $label->enabled}checked{/if} />
+                                                        <label class="form-check-label" for="active_checkbox">Активен</label>
+                                                </div>
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="in_filter" value="1" type="checkbox" role="switch" id="in_filter_checkbox"
+                                                                {if $label->in_filter}checked{/if} />
+                                                        <label class="form-check-label" for="in_filter_checkbox">Использовать в фильтре заказов</label>
+                                                </div>
 					</div>
 				</div>
 

--- a/templates/admin/order/payment.tpl
+++ b/templates/admin/order/payment.tpl
@@ -20,16 +20,16 @@
 			<div class="col-12">
 				<div class="over_name">
 					<div class="checkbox_line">
-						<div class="form-check">
-							<input class="form-check-input" name="enabled" value="1" type="checkbox" id="enabled"
-								{if $payment_method->enabled}checked{/if} />
-							<label class="form-check-label" for="enabled">Показывать менеджеру</label>
-						</div>
-						<div class="form-check">
-							<input class="form-check-input" name="enabled_public" value="1" type="checkbox"
-								id="enabled_public" {if $payment_method->enabled_public}checked{/if} />
-							<label class="form-check-label" for="enabled_public">Показывать клиенту при заказе</label>
-						</div>
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="enabled" value="1" type="checkbox" role="switch" id="enabled"
+                                                                {if $payment_method->enabled}checked{/if} />
+                                                        <label class="form-check-label" for="enabled">Показывать менеджеру</label>
+                                                </div>
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="enabled_public" value="1" type="checkbox" role="switch"
+                                                                id="enabled_public" {if $payment_method->enabled_public}checked{/if} />
+                                                        <label class="form-check-label" for="enabled_public">Показывать клиенту при заказе</label>
+                                                </div>
 					</div>
 				</div>
 

--- a/templates/admin/product/brand.tpl
+++ b/templates/admin/product/brand.tpl
@@ -21,11 +21,11 @@
 			<div class="col-12">
 				<div class="over_name">
 					<div class="checkbox_line">
-						<div class="form-check">
-							<input class="form-check-input" name="featured" value="1" type="checkbox" id="featured_checkbox"
-								{if $brand->featured}checked{/if} />
-							<label class="form-check-label" for="featured_checkbox">Избранный</label>
-						</div>
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="featured" value="1" type="checkbox" role="switch" id="featured_checkbox"
+                                                                {if $brand->featured}checked{/if} />
+                                                        <label class="form-check-label" for="featured_checkbox">Избранный</label>
+                                                </div>
 					</div>
 				</div>
 				<div class="name_row">

--- a/templates/admin/user/mailing.tpl
+++ b/templates/admin/user/mailing.tpl
@@ -26,16 +26,16 @@
 			<div class="col-12">
 				<div class="over_name">
 					<div class="checkbox_line">
-						<div class="form-check">
-							<input class="form-check-input" name="send" value="1" type="checkbox" id="send"
-								{if $mailing->send}checked{/if} />
-							<label class="form-check-label" for="send">Отправлен</label>
-						</div>
-						<div class="form-check">
-							<input class="form-check-input" name="frozen" value="1" type="checkbox" id="frozen"
-								{if $mailing->frozen}checked{/if} />
-							<label class="form-check-label" for="frozen">Заморожен</label>
-						</div>
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="send" value="1" type="checkbox" role="switch" id="send"
+                                                                {if $mailing->send}checked{/if} />
+                                                        <label class="form-check-label" for="send">Отправлен</label>
+                                                </div>
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="frozen" value="1" type="checkbox" role="switch" id="frozen"
+                                                                {if $mailing->frozen}checked{/if} />
+                                                        <label class="form-check-label" for="frozen">Заморожен</label>
+                                                </div>
 					</div>
 				</div>
 				<div class="name_row">

--- a/templates/admin/user/notifier.tpl
+++ b/templates/admin/user/notifier.tpl
@@ -19,11 +19,11 @@
 			<div class="col-12">
 				<div class="over_name">
 					<div class="checkbox_line">
-						<div class="form-check">
-							<input class="form-check-input" name="enabled" value="1" type="checkbox" id="enabled"
-								{if $notifier->enabled}checked{/if} />
-							<label class="form-check-label" for="enabled">Активный</label>
-						</div>
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="enabled" value="1" type="checkbox" role="switch" id="enabled"
+                                                                {if $notifier->enabled}checked{/if} />
+                                                        <label class="form-check-label" for="enabled">Активный</label>
+                                                </div>
 					</div>
 				</div>
 

--- a/templates/admin/user/user.tpl
+++ b/templates/admin/user/user.tpl
@@ -31,16 +31,16 @@
 			<div class="col-12">
 				<div class="over_name">
 					<div class="checkbox_line">
-						<div class="form-check">
-							<input class="form-check-input" name="enabled" value='1' type="checkbox" id="active_checkbox"
-								{if !'user_edit'|user_access}disabled{/if} {if $current_user->enabled}checked{/if} />
-							<label for="active_checkbox">Активен</label>
-						</div>
-						<div class="form-check">
-							<input class="form-check-input" name="manager" value='1' type="checkbox" id="manager_checkbox"
-								{if !'user_manager'|user_access}disabled{/if} {if $current_user->manager}checked{/if} />
-							<label class="form-check-label" for="manager_checkbox">Сотрудник</label>
-						</div>
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="enabled" value='1' type="checkbox" role="switch" id="active_checkbox"
+                                                                {if !'user_edit'|user_access}disabled{/if} {if $current_user->enabled}checked{/if} />
+                                                        <label class="form-check-label" for="active_checkbox">Активен</label>
+                                                </div>
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="manager" value='1' type="checkbox" role="switch" id="manager_checkbox"
+                                                                {if !'user_manager'|user_access}disabled{/if} {if $current_user->manager}checked{/if} />
+                                                        <label class="form-check-label" for="manager_checkbox">Сотрудник</label>
+                                                </div>
 					</div>
 				</div>
 

--- a/templates/admin/warehouse/place.tpl
+++ b/templates/admin/warehouse/place.tpl
@@ -19,8 +19,8 @@
             <div class="col-12">
                 <div class="over_name">
                     <div class="checkbox_line">
-                        <div class="form-check">
-                            <input class="form-check-input" name="enabled" value="1" type="checkbox" id="enabled_checkbox"
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" name="enabled" value="1" type="checkbox" role="switch" id="enabled_checkbox"
                                 {if $place->enabled}checked{/if} />
                             <label class="form-check-label" for="enabled_checkbox">Активный</label>
                         </div>

--- a/templates/admin/warehouse/provider.tpl
+++ b/templates/admin/warehouse/provider.tpl
@@ -19,11 +19,11 @@
 			<div class="col-12">
 				<div class="over_name">
 					<div class="checkbox_line">
-						<div class="form-check">
-							<input class="form-check-input" name="no_restore_price" value="1" type="checkbox"
-								id="no_restore_price_checkbox" {if $provider->no_restore_price}checked{/if} />
-							<label class="form-check-label" for="no_restore_price_checkbox">Не обнулять склад</label>
-						</div>
+                                                <div class="form-check form-switch">
+                                                        <input class="form-check-input" name="no_restore_price" value="1" type="checkbox" role="switch"
+                                                                id="no_restore_price_checkbox" {if $provider->no_restore_price}checked{/if} />
+                                                        <label class="form-check-label" for="no_restore_price_checkbox">Не обнулять склад</label>
+                                                </div>
 					</div>
 				</div>
 


### PR DESCRIPTION
## Summary
- convert checkbox markup inside `checkbox_line` containers to use `form-check form-switch`
- mark inputs with `role="switch"`

## Testing
- `composer validate --no-check-all` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68634edb24708326b32c3ebb3ae902aa