### PR TITLE
Move Extension model to Service

### DIFF
--- a/hugashop/crm/Services/Design.php
+++ b/hugashop/crm/Services/Design.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 4.7
+ * @version 4.8
  *
  * Smarty 5.x require PHP7.4/PHP8.1
  *
@@ -23,7 +23,7 @@ use HugaShop\Services\Config;
 use HugaShop\Services\Helper;
 use HugaShop\Services\Request;
 use HugaShop\Models\Settings;
-use HugaShop\Models\Extension;
+use HugaShop\Services\Extension;
 use HugaShop\Models\User\UserPermission;
 use HugaShop\Models\Finance\FinanceCurrency;
 

--- a/hugashop/crm/Services/Extension.php
+++ b/hugashop/crm/Services/Extension.php
@@ -4,11 +4,11 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.3
+ * @version 1.4
  *
  */
 
-namespace HugaShop\Models;
+namespace HugaShop\Services;
 
 use HugaShop\Models\Settings;
 use HugaShop\Services\Config;

--- a/src/Controller/Admin/Ajax/UpdateEntityAjax.php
+++ b/src/Controller/Admin/Ajax/UpdateEntityAjax.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.7
+ * @version 1.8
  *
  */
 
@@ -14,7 +14,7 @@ use HugaShop\Models\User\User;
 use HugaShop\Models\Order\Order;
 use HugaShop\Models\Product\Product;
 use HugaShop\Services\Request;
-use HugaShop\Models\Extension;
+use HugaShop\Services\Extension;
 use HugaShop\Models\Order\OrderLabel;
 use HugaShop\Models\Content\ContentPage;
 use HugaShop\Models\Content\ContentPost;

--- a/src/Controller/Admin/Extension/ExtensionController.php
+++ b/src/Controller/Admin/Extension/ExtensionController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.1
+ * @version 2.2
  *
  */
 
@@ -12,7 +12,7 @@ namespace App\Controller\Admin\Extension;
 
 use HugaShop\Services\Design;
 use HugaShop\Services\Request;
-use HugaShop\Models\Extension;
+use HugaShop\Services\Extension;
 use App\Controller\BaseAdminController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;

--- a/src/Controller/Admin/Extension/ExtensionListController.php
+++ b/src/Controller/Admin/Extension/ExtensionListController.php
@@ -4,14 +4,14 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.0
+ * @version 2.1
  *
  */
 
 namespace App\Controller\Admin\Extension;
 
 use HugaShop\Services\Design;
-use HugaShop\Models\Extension;
+use HugaShop\Services\Extension;
 use App\Controller\BaseAdminController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;

--- a/src/Controller/Front/Exchange/ExtensionController.php
+++ b/src/Controller/Front/Exchange/ExtensionController.php
@@ -3,13 +3,13 @@
 /**
  *
  * @author Andi Huga
- * @version 1.9
+ * @version 2.0
  *
  */
 
 namespace App\Controller\Front\Exchange;
 
-use HugaShop\Models\Extension;
+use HugaShop\Services\Extension;
 use App\Controller\BaseFrontController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;


### PR DESCRIPTION
## Summary
- move `hugashop/crm/Models/Extension.php` into Services
- adjust namespace and usages

## Testing
- `php composer.phar dump-autoload -o` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686372d9f7ac8326ac919e5a7826eadb