### PR TITLE
Implement async product filling calculation

### DIFF
--- a/hugashop/crm/Extensions/ProductFilling/ProductFilling.php
+++ b/hugashop/crm/Extensions/ProductFilling/ProductFilling.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  * 
  * @author Andri Huga
- * @version 1.2
+ * @version 1.3
  * 
  * Extension calculates content filling percent for products
  */
@@ -21,6 +21,7 @@ use HugaShop\Extensions\ProductsImport\Services\Calculate;
 
 final class ProductFilling extends BaseExtension
 {
+    private int $batch = 100;
 
 
     /**
@@ -58,10 +59,32 @@ final class ProductFilling extends BaseExtension
 
 
     /**
-     * Ajax
+     * Recalculate products filling
      */
     public function calculate()
     {
+        if (Request::isAjax()) {
+            $from = max(0, Request::getInt('from'));
+            $filter = [
+                'limit' => $this->batch,
+                'page'  => intdiv($from, $this->batch) + 1
+            ];
+
+            $products = Product::getProducts($filter);
+            foreach ($products as $product) {
+                Calculate::calculateProduct($product->id);
+            }
+
+            $total = Product::countProducts();
+            $processed = $from + $products->count();
+
+            return (object) [
+                'from'  => $processed,
+                'total' => $total,
+                'end'   => $processed >= $total,
+            ];
+        }
+
         if (Request::post('calculate')) {
             Calculate::calculateAllProducts();
             Request::makeRedirect('/admin/extension/ProductFilling');

--- a/hugashop/crm/Extensions/ProductFilling/templates/product_list.tpl
+++ b/hugashop/crm/Extensions/ProductFilling/templates/product_list.tpl
@@ -19,10 +19,8 @@
                         {$products_count|plural:'товар':'товаров':'товара'}</span></h1>
             {/if}
             
-            <form method="post" class="d-inline-block ms-2">
-                {getCSRFInput}
-                <button class="btn btn-primary" type="submit" name="calculate" value="1">Посчитать</button>
-            </form>
+            <button class="btn btn-primary ms-2" id="calculate_btn" type="button">Посчитать</button>
+            <span id="calculate_result" class="ms-1"></span>
 
             <form method="get" id="search">
                 {getCSRFInput}
@@ -104,4 +102,48 @@
             {/if}
         </div>
     </div>
+{/block}
+
+{block name=body_script append}
+    <script type="module">
+        import '{"js/piecon/piecon.js"|asset}';
+
+        $(function() {
+            let ajax_url = '/admin/extension/{$extension->module}/ajax/calculate';
+            let in_process = false;
+            let total = {$products_count};
+            let processed = 0;
+
+            $('#calculate_btn').on('click', function(e) {
+                e.preventDefault();
+                if (in_process) {
+                    return;
+                }
+                in_process = true;
+                Piecon.setOptions({fallback: 'force'});
+                Piecon.setProgress(0);
+                $('#calculate_result').text('0/' + total);
+                do_calculate(processed);
+            });
+
+            function do_calculate(from) {
+                $.ajax({
+                    url: ajax_url,
+                    data: {from: from},
+                    dataType: 'json',
+                    success: function(data) {
+                        processed = data.from;
+                        Piecon.setProgress(Math.round(100 * processed / total));
+                        $('#calculate_result').text(processed + '/' + total);
+                        if (data && !data.end) {
+                            do_calculate(processed);
+                        } else {
+                            Piecon.setProgress(100);
+                            in_process = false;
+                        }
+                    }
+                });
+            }
+        });
+    </script>
 {/block}


### PR DESCRIPTION
## Summary
- add batch option for ProductFilling extension
- process 100 products per request in calculate() with AJAX support
- update admin template to show progress and send async requests

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864d4feb2f08326b099d6df61bb4cf8