### PR TITLE
Move translation to OpenAI extension

### DIFF
--- a/hugashop/crm/Extensions/OpenAI/OpenAI.php
+++ b/hugashop/crm/Extensions/OpenAI/OpenAI.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ *
+ * OpenAI integration
+ */
+
+namespace HugaShop\Extensions\OpenAI;
+
+use OpenAI;
+use HugaShop\Services\Config;
+use HugaShop\Services\Request;
+use HugaShop\Extensions\BaseExtension;
+use HugaShop\Models\Product\Product;
+use HugaShop\Models\Content\ContentPage;
+use HugaShop\Models\Content\ContentPost;
+use HugaShop\Models\Product\ProductBrand;
+use HugaShop\Models\Localization\Language;
+
+final class OpenAI extends BaseExtension
+{
+    /**
+     * Translate model fields using OpenAI
+     */
+    public function translate()
+    {
+        if (!Request::checkCSRF()) {
+            return ['error' => 'csrf'];
+        }
+
+        $entity    = Request::post('entity', 'string');
+        $id        = Request::postInt('id');
+        $lang_code = Request::post('lang', 'string');
+
+        if (empty($entity) || empty($id) || empty($lang_code)) {
+            return ['error' => 'params'];
+        }
+
+        $language = Language::getOne(['code' => $lang_code]);
+        if (empty($language)) {
+            return ['error' => 'language'];
+        }
+
+        if ($language->code == Language::getMain()->code) {
+            return ['error' => 'is_main_language'];
+        }
+
+        $model = null;
+        switch ($entity) {
+            case 'product':
+                $this->checkAdminAccess('product_content');
+                $model = Product::query()->find($id);
+                break;
+            case 'blog':
+                $this->checkAdminAccess('blog');
+                $model = ContentPost::query()->find($id);
+                break;
+            case 'page':
+                $this->checkAdminAccess('page');
+                $model = ContentPage::query()->find($id);
+                break;
+            case 'brand':
+                $this->checkAdminAccess('product_brand');
+                $model = ProductBrand::query()->find($id);
+                break;
+            default:
+                return ['error' => 'entity'];
+        }
+
+        if (empty($model)) {
+            return ['error' => 'not_found'];
+        }
+
+        $key = $this->getSetting('api_key') ?? Config::get('openai')->key;
+        if (empty($key)) {
+            return ['error' => 'openai_key'];
+        }
+
+        $client = OpenAI::client($key);
+
+        $translated = [];
+        foreach ($model::getTranslatableFields() as $field) {
+            if (!empty($model->$field)) {
+                $result = $client->chat()->create([
+                    'model' => 'gpt-4o',
+                    'messages' => [
+                        ['role' => 'user', 'content' => 'Переведи на ' . $language->name . ': ' . $model->$field],
+                    ],
+                ]);
+                $translated[$field] = trim($result->choices[0]->message->content);
+            }
+        }
+
+        return $translated;
+    }
+}

--- a/hugashop/crm/Extensions/OpenAI/settings.yaml
+++ b/hugashop/crm/Extensions/OpenAI/settings.yaml
@@ -1,0 +1,5 @@
+name: "OpenAI"
+description: "Интеграция с OpenAI"
+settings_params:
+  - { variable: api_key, name: "Api key" }
+version: 1.0

--- a/src/Controller/Admin/Ajax/TranslateAjax.php
+++ b/src/Controller/Admin/Ajax/TranslateAjax.php
@@ -4,21 +4,13 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.2
+ * @version 1.3
  */
 
 namespace App\Controller\Admin\Ajax;
 
-use OpenAI;
-use HugaShop\Services\Config;
-use HugaShop\Services\Request;
-use App\Services\LanguageService;
-use HugaShop\Models\Product\Product;
+use HugaShop\Services\Extension;
 use App\Controller\BaseAdminController;
-use HugaShop\Models\Content\ContentPage;
-use HugaShop\Models\Content\ContentPost;
-use HugaShop\Models\Product\ProductBrand;
-use HugaShop\Models\Localization\Language;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -27,74 +19,12 @@ class TranslateAjax extends BaseAdminController
     #[Route('/admin/ajax/translate', name: 'TranslateAjaxAdmin')]
     public function translate()
     {
-        if (!Request::checkCSRF()) {
-            return new JsonResponse(['error' => 'csrf'], 400);
+        $Ext = Extension::makeExtension('OpenAI');
+
+        if (empty($Ext)) {
+            return new JsonResponse(['error' => 'extension'], 500);
         }
 
-        $entity    = Request::post('entity', 'string');
-        $id        = Request::postInt('id');
-        $lang_code = Request::post('lang', 'string');
-
-        if (empty($entity) || empty($id) || empty($lang_code)) {
-            return new JsonResponse(['error' => 'params'], 400);
-        }
-
-        $language = Language::getOne(['code' => $lang_code]);
-
-        if (empty($language)) {
-            return new JsonResponse(['error' => 'language'], 400);
-        }
-
-        if ($language->code == Language::getMain()->code) {
-            return new JsonResponse(['error' => 'is_main_language'], 400);
-        }
-
-        $model = null;
-        switch ($entity) {
-            case 'product':
-                $this->checkAdminAccess('product_content');
-                $model = Product::query()->find($id);
-                break;
-            case 'blog':
-                $this->checkAdminAccess('blog');
-                $model = ContentPost::query()->find($id);
-                break;
-            case 'page':
-                $this->checkAdminAccess('page');
-                $model = ContentPage::query()->find($id);
-                break;
-            case 'brand':
-                $this->checkAdminAccess('product_brand');
-                $model = ProductBrand::query()->find($id);
-                break;
-            default:
-                return new JsonResponse(['error' => 'entity'], 400);
-        }
-
-        if (empty($model)) {
-            return new JsonResponse(['error' => 'not_found'], 404);
-        }
-
-        $key = Config::get('openai')->key;
-        if (empty($key)) {
-            return new JsonResponse(['error' => 'openai_key'], 500);
-        }
-
-        $client = OpenAI::client($key);
-
-        $translated = [];
-        foreach ($model::getTranslatableFields() as $field) {
-            if (!empty($model->$field)) {
-                $result = $client->chat()->create([
-                    'model' => 'gpt-4o',
-                    'messages' => [
-                        ['role' => 'user', 'content' => 'Переведи на ' . $language->name . ': ' . $model->$field],
-                    ],
-                ]);
-                $translated[$field] = trim($result->choices[0]->message->content);
-            }
-        }
-
-        return new JsonResponse($translated);
+        return new JsonResponse($Ext->translate());
     }
 }


### PR DESCRIPTION
## Summary
- implement new OpenAI extension with translate method
- expose `api_key` setting for the extension
- call OpenAI extension from TranslateAjax controller

## Testing
- `php -l hugashop/crm/Extensions/OpenAI/OpenAI.php` *(fails: `php` not found)*
- `composer validate --no-check-all --strict` *(fails: `composer` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68671900e13c83269cfb52e9feb913ec