### PR TITLE
Add save option for product translation via OpenAI

### DIFF
--- a/hugashop/crm/Extensions/OpenAI/OpenAI.php
+++ b/hugashop/crm/Extensions/OpenAI/OpenAI.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.0
+ * @version 1.1
  *
  * OpenAI integration
  */
@@ -35,6 +35,7 @@ final class OpenAI extends BaseExtension
         $entity    = Request::post('entity', 'string');
         $id        = Request::postInt('id');
         $lang_code = Request::post('lang', 'string');
+        $save      = Request::post('save', 'int');
 
         if (empty($entity) || empty($id) || empty($lang_code)) {
             return ['error' => 'params'];
@@ -93,6 +94,10 @@ final class OpenAI extends BaseExtension
                 ]);
                 $translated[$field] = trim($result->choices[0]->message->content);
             }
+        }
+
+        if ($save && !empty($translated)) {
+            $model::updateTranslation($model->id, $language->code, $translated);
         }
 
         return $translated;

--- a/hugashop/crm/Extensions/ProductFilling/templates/product_list.tpl
+++ b/hugashop/crm/Extensions/ProductFilling/templates/product_list.tpl
@@ -219,6 +219,7 @@
                                 entity: 'product',
                                 id: productId,
                                 lang: lang,
+                                save: 1,
                                 csrf: csrf
                             },
                             success: function() {


### PR DESCRIPTION
## Summary
- update OpenAI integration to optionally persist generated translations
- send `save` flag from product list translation requests

## Testing
- `composer -V` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68698fb4032c832693e273fbc91345c6