### PR TITLE
Add document language setting to FopUa

### DIFF
--- a/hugashop/crm/Models/Order/OrderPayment.php
+++ b/hugashop/crm/Models/Order/OrderPayment.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 3.6
+ * @version 3.7
  *
  */
 
@@ -16,6 +16,7 @@ use HugaShop\Services\Helper;
 use HugaShop\Models\BaseModel;
 use HugaShop\Models\Finance\FinancePurse;
 use HugaShop\Models\Finance\FinanceCurrency;
+use HugaShop\Models\Localization\Language;
 
 class OrderPayment extends BaseModel
 {
@@ -116,7 +117,27 @@ class OrderPayment extends BaseModel
      */
     public static function getPaymentModules()
     {
-        return Helper::getModules(Config::get('payment_dir'));
+        $modules = Helper::getModules(Config::get('payment_dir'));
+
+        $languages = Language::getLanguages();
+        foreach ($modules as $module) {
+            if (empty($module->settings_params)) {
+                continue;
+            }
+            foreach ($module->settings_params as $param) {
+                if ($param->variable === 'document_language') {
+                    $param->options = [];
+                    foreach ($languages as $lang) {
+                        $param->options[] = (object) [
+                            'name'  => $lang->name,
+                            'value' => $lang->code
+                        ];
+                    }
+                }
+            }
+        }
+
+        return $modules;
     }
 
 

--- a/hugashop/crm/Modules/Payment/FopUa/FopUa.php
+++ b/hugashop/crm/Modules/Payment/FopUa/FopUa.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.3
+ * @version 2.4
  *
  * Использует библиотку intl (MessageFormatter)
  * Установка на Linus: sudo apt-get install php7.4-intl
@@ -28,6 +28,8 @@ use HugaShop\Models\Finance\FinanceCurrency;
 use HugaShop\Models\Order\OrderPayment;
 use HugaShop\Models\Order\OrderPurchase;
 use HugaShop\Models\Order\OrderDelivery;
+use HugaShop\Models\Localization\Language;
+use HugaShop\Models\Product\Product;
 
 class FopUa
 {
@@ -104,7 +106,18 @@ class FopUa
             // Выбираем товары заказа
             $purchases = [];
             if (!empty($order) and !empty($purchases = OrderPurchase::getPurchases(['order_id' => $order->id], ['image']))) {
+                $doc_lang = $payment_method->settings->document_language ?? Language::getMain()->code;
                 foreach ($purchases as &$purchase) {
+
+                    if (!empty($purchase->product_id) && $doc_lang) {
+                        $translation = Product::getTranslation($purchase->product_id, $doc_lang);
+                        if (!empty($translation->name)) {
+                            $purchase->product_name = $translation->name;
+                        }
+                        if (!empty($translation->variant_name)) {
+                            $purchase->variant_name = $translation->variant_name;
+                        }
+                    }
 
                     // Вычисляем скидку %
                     $purchase->price = $purchase->price - ($purchase->price * ($order->discount / 100));

--- a/hugashop/crm/Modules/Payment/FopUa/settings.yaml
+++ b/hugashop/crm/Modules/Payment/FopUa/settings.yaml
@@ -9,5 +9,6 @@ settings_params:
   - { variable: recipient_adress, name: "Юр. адреса:" }
   - { variable: pense, name: "Обозначение копеек", default: "коп." }
   - { variable: tax, name: "Налоги ФОП % (платит покупатель)", default: 0 }
+  - { variable: document_language, name: "Язык документов" }
   - { variable: stamp_file, name: "Штамп (.png)", type: file }
   - { variable: sign_file, name: "Подпись (.png)", type: file }


### PR DESCRIPTION
## Summary
- add `document_language` option to FopUa settings
- populate language options dynamically in `OrderPayment` model
- translate product names in FopUa invoices

## Testing
- `composer validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a884a1908326912e9ca6e99f4dd9