### PR TITLE
Add date range filters to daily stats

### DIFF
--- a/assets/admin/js/chart.js
+++ b/assets/admin/js/chart.js
@@ -3,7 +3,7 @@
  * Functions related to rendering ApexCharts graphs
  *
  * @author Andri Huga
- * @version 1.2
+ * @version 1.3
  */
 
 export function makeChart(element, chartOptions = {}, datasets = []) {
@@ -103,6 +103,12 @@ export function getChartData(apex, filter, options) {
 
         if (options.range === 'month') {
             filter.fromDate = now.minus({ months: 1 }).toISODate();
+            filter.toDate = now.plus({ day: 1 }).toISODate();
+        } else if (options.range === 'quarter') {
+            filter.fromDate = now.minus({ months: 3 }).toISODate();
+            filter.toDate = now.plus({ day: 1 }).toISODate();
+        } else if (options.range === 'half_year') {
+            filter.fromDate = now.minus({ months: 6 }).toISODate();
             filter.toDate = now.plus({ day: 1 }).toISODate();
         } else if (options.range === 'year') {
             filter.fromDate = now.minus({ years: 1 }).toISODate();

--- a/templates/admin/finance/stats.tpl
+++ b/templates/admin/finance/stats.tpl
@@ -29,6 +29,9 @@
       <div class="col-12">
          <div class="grafic">
             <div class="chart_actions btn_row">
+               <a class="btn btn-light" id="day_chart_month">месяц</a>
+               <a class="btn btn-light" id="day_chart_quarter">квартал</a>
+               <a class="btn btn-light" id="day_chart_half_year">полгода</a>
                <a class="btn btn-light" id="day_chart_reset">Reset zoom</a>
             </div>
             <div>
@@ -168,6 +171,15 @@
                }
             });
 
+            $('#day_chart_month').click(function() {
+               byDay.load({ range: 'month' });
+            });
+            $('#day_chart_quarter').click(function() {
+               byDay.load({ range: 'quarter' });
+            });
+            $('#day_chart_half_year').click(function() {
+               byDay.load({ range: 'half_year' });
+            });
             $('#day_chart_reset').click(function() {
                if (byDay.chart) byDay.chart.resetSeries();
             });


### PR DESCRIPTION
## Summary
- add month/quarter/half-year buttons for stats_byDay chart
- handle new range buttons in stats.js
- support new ranges in chart utilities

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6869b49c22048326932594cebd4e79b2