### PR TITLE
Add country code field for languages

### DIFF
--- a/hugashop/crm/Models/Localization/Language.php
+++ b/hugashop/crm/Models/Localization/Language.php
@@ -5,7 +5,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.9
+ * @version 2.0
  *
  */
 
@@ -20,6 +20,7 @@ class Language extends BaseModel
     protected static $table_fields = [
         'id' =>             ['type' => 'int',      'extra' => 'AUTO_INCREMENT'],
         'code' =>           ['type' => 'varchar'],
+        'country_code' =>   ['type' => 'varchar'],
         'name' =>           ['type' => 'varchar'],
         'main' =>           ['type' => 'tinyint',  'def' => 0]
     ];

--- a/src/Controller/Admin/Settings/LanguageController.php
+++ b/src/Controller/Admin/Settings/LanguageController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.1
+ * @version 1.2
  *
  */
 
@@ -52,7 +52,47 @@ class LanguageController extends BaseAdminController
             }
         }
 
+        $languageCodes = [
+            'aa','ab','ae','af','ak','am','an','ar','as','av','ay','az','ba','be',
+            'bg','bh','bi','bm','bn','bo','br','bs','ca','ce','ch','co','cr','cs',
+            'cu','cv','cy','da','de','dv','dz','ee','el','en','eo','es','et','eu',
+            'fa','ff','fi','fj','fo','fr','fy','ga','gd','gl','gn','gu','gv','ha',
+            'he','hi','ho','hr','ht','hu','hy','hz','ia','id','ie','ig','ii','ik',
+            'io','is','it','iu','ja','jv','ka','kg','ki','kj','kk','kl','km','kn',
+            'ko','kr','ks','ku','kv','kw','ky','la','lb','lg','li','ln','lo','lt',
+            'lu','lv','mg','mh','mi','mk','ml','mn','mr','ms','mt','my','na','nb',
+            'nd','ne','ng','nl','nn','no','nr','nv','ny','oc','oj','om','or','os',
+            'pa','pi','pl','ps','pt','qu','rm','rn','ro','ru','rw','sa','sc','sd',
+            'se','sg','si','sk','sl','sm','sn','so','sq','sr','ss','st','su','sv',
+            'sw','ta','te','tg','th','ti','tk','tl','tn','to','tr','ts','tt','tw',
+            'ty','ug','uk','ur','uz','ve','vi','vo','wa','wo','xh','yi','yo','za',
+            'zh','zu'
+        ];
+
+        $countryCodes = [
+            'AF','AX','AL','DZ','AS','AD','AO','AI','AQ','AG','AR','AM','AW','AU',
+            'AT','AZ','BS','BH','BD','BB','BY','BE','BZ','BJ','BM','BT','BO','BQ',
+            'BA','BW','BV','BR','IO','BN','BG','BF','BI','CV','KH','CM','CA','KY',
+            'CF','TD','CL','CN','CX','CC','CO','KM','CG','CD','CK','CR','CI','HR',
+            'CU','CW','CY','CZ','DK','DJ','DM','DO','EC','EG','SV','GQ','ER','EE',
+            'ET','FK','FO','FJ','FI','FR','GF','PF','TF','GA','GM','GE','DE','GH',
+            'GI','GR','GL','GD','GP','GU','GT','GG','GN','GW','GY','HT','HM','VA',
+            'HN','HK','HU','IS','IN','ID','IR','IQ','IE','IM','IL','IT','JM','JP',
+            'JE','JO','KZ','KE','KI','KP','KR','KW','KG','LA','LV','LB','LS','LR',
+            'LY','LI','LT','LU','MO','MK','MG','MW','MY','MV','ML','MT','MH','MQ',
+            'MR','MU','YT','MX','FM','MD','MC','MN','ME','MS','MA','MZ','MM','NA',
+            'NR','NP','NL','NC','NZ','NI','NE','NG','NU','NF','MP','NO','OM','PK',
+            'PW','PS','PA','PG','PY','PE','PH','PN','PL','PT','PR','QA','RE','RO',
+            'RU','RW','BL','SH','KN','LC','MF','PM','VC','WS','SM','ST','SA','SN',
+            'RS','SC','SL','SG','SX','SK','SI','SB','SO','ZA','GS','SS','ES','LK',
+            'SD','SR','SJ','SE','CH','SY','TW','TJ','TZ','TH','TL','TG','TK','TO',
+            'TT','TN','TR','TM','TC','TV','UG','UA','AE','GB','US','UM','UY','UZ',
+            'VU','VE','VN','VG','VI','WF','EH','YE','ZM','ZW'
+        ];
+
         Design::assign('language', $language);
+        Design::assign('language_codes', $languageCodes);
+        Design::assign('country_codes', $countryCodes);
 
         return $this->fetchResponse('settings/language.tpl');
     }

--- a/templates/admin/settings/language.tpl
+++ b/templates/admin/settings/language.tpl
@@ -26,8 +26,20 @@
             <div class="col-lg-6 layer">
                 <ul class="property_block">
                     <li class="row_sm">
-                        <label class="col-form-label" for="code">Код</label>
-                        <input class="form-control" id="code" name="code" type="text" value="{$language->code}" />
+                        <label class="col-form-label" for="code">Код языка</label>
+                        <select class="form-select" id="code" name="code">
+                            {foreach $language_codes as $lc}
+                                <option value="{$lc}" {if $language->code == $lc}selected{/if}>{$lc}</option>
+                            {/foreach}
+                        </select>
+                    </li>
+                    <li class="row_sm">
+                        <label class="col-form-label" for="country_code">Код страны</label>
+                        <select class="form-select" id="country_code" name="country_code">
+                            {foreach $country_codes as $cc}
+                                <option value="{$cc}" {if $language->country_code == $cc}selected{/if}>{$cc}</option>
+                            {/foreach}
+                        </select>
                     </li>
                     <li class="row_sm">
                         <div class="form-check">


### PR DESCRIPTION
## Summary
- extend Language model with `country_code` field
- load ISO language and country codes in `LanguageController`
- show new dropdowns for language and country codes in admin UI

## Testing
- `php` commands not available, unable to run tests

------
https://chatgpt.com/codex/tasks/task_e_6869f4cb7ed48326b990eb82e14a9602