### PR TITLE
Optimize translation lookup

### DIFF
--- a/hugashop/crm/Models/BaseModel.php
+++ b/hugashop/crm/Models/BaseModel.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.0
+ * @version 2.2
  *
  */
 
@@ -227,7 +227,17 @@ abstract class BaseModel extends Model
         }
 
         return $model->runWithInitTable(function () use ($query) {
-            return $query->get();
+            $result = $query->get();
+
+            foreach ($result as $item) {
+                $item->settings = empty($item->settings) ? new \stdClass() : (object) unserialize($item->settings);
+            }
+
+            if ($language_code = Language::checkOrGetCode() and static::isTranslatable()) {
+                static::fillTranslations($result, $language_code);
+            }
+
+            return $result;
         });
     }
 

--- a/hugashop/crm/Models/Traits/TranslationTrait.php
+++ b/hugashop/crm/Models/Traits/TranslationTrait.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.6
+ * @version 1.7
  *
  */
 
@@ -60,6 +60,43 @@ trait TranslationTrait
             $entity->$field = $translation->$field ?? null;
         }
         return $entity;
+    }
+
+
+    /**
+     * Fill list of entities with translations using one DB query
+     */
+    public static function fillTranslations(iterable $entities, string $code): iterable
+    {
+        $ids = [];
+        foreach ($entities as $item) {
+            if (!empty($item->id)) {
+                $ids[] = $item->id;
+            }
+        }
+
+        if (empty($ids)) {
+            return $entities;
+        }
+
+        $model = AbstractTranslation::setTableTranslation(static::class);
+        $translations = $model->runWithInitTable(function () use ($model, $ids, $code) {
+            return $model->newQuery()
+                ->where('language_code', $code)
+                ->whereIn('entity_id', $ids)
+                ->get()
+                ->keyBy('entity_id');
+        });
+
+        $fields = static::getTranslatableFields();
+        foreach ($entities as $item) {
+            $translation = $translations[$item->id] ?? null;
+            foreach ($fields as $field) {
+                $item->$field = $translation->$field ?? null;
+            }
+        }
+
+        return $entities;
     }
 
 


### PR DESCRIPTION
## Summary
- bump BaseModel version to 2.2
- add fillTranslations method for bulk translation retrieval
- use the new method in BaseModel::getList

## Testing
- `php -l hugashop/crm/Models/BaseModel.php`
- `php -l hugashop/crm/Models/Traits/TranslationTrait.php`


------
https://chatgpt.com/codex/tasks/task_e_686ab8e4aee8832680d69100e14f49fc