### PR TITLE
Fix cart popup locale

### DIFF
--- a/assets/grizlicnc/init.js
+++ b/assets/grizlicnc/init.js
@@ -173,9 +173,15 @@ $(function () {
         getCartInformer(item.product_id, item.amount, function () {
 
             // Popup
+            const locale = document.documentElement.getAttribute('lang');
+            let cartUrl = '/cart';
+            if (locale) {
+                cartUrl = '/' + locale + cartUrl;
+            }
+
             $.fancybox.open({
                 type: 'ajax',
-                src: '/cart',
+                src: cartUrl,
                 touch: false,
                 closeExisting: true,
                 afterShow: asignFancyAjax


### PR DESCRIPTION
## Summary
- keep locale when opening cart popup

## Testing
- `node --check assets/grizlicnc/init.js`


------
https://chatgpt.com/codex/tasks/task_e_686b7a20cbb4832681522a3e80103345