### PR TITLE
Enable multi-language editing for SeoPage

### DIFF
--- a/hugashop/crm/Extensions/OpenAI/OpenAI.php
+++ b/hugashop/crm/Extensions/OpenAI/OpenAI.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.1
+ * @version 1.2
  *
  * OpenAI integration
  */
@@ -21,6 +21,7 @@ use HugaShop\Models\User\UserPermission;
 use HugaShop\Models\Product\ProductBrand;
 use HugaShop\Models\Localization\Language;
 use HugaShop\Models\Product\ProductCategory;
+use HugaShop\Extensions\SeoPage\Models\SeoPage as SeoPageModel;
 
 final class OpenAI extends BaseExtension
 {
@@ -72,6 +73,10 @@ final class OpenAI extends BaseExtension
             case 'brand':
                 UserPermission::checkAccess('product_brand');
                 $model = ProductBrand::query()->find($id);
+                break;
+            case 'seo_page':
+                UserPermission::checkAccess('extension');
+                $model = SeoPageModel::query()->find($id);
                 break;
             default:
                 return ['error' => 'entity'];

--- a/hugashop/crm/Extensions/SeoPage/Models/SeoPage.php
+++ b/hugashop/crm/Extensions/SeoPage/Models/SeoPage.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.6
+ * @version 1.7
  *
  */
 
@@ -17,12 +17,12 @@ final class SeoPage extends BaseExtensionModel
 
     protected static $table_fields = [
         'id' =>                     ['type' => 'int',           'extra' => 'AUTO_INCREMENT'],
-        'name' =>                   ['type' => 'varchar',       'required' => 'true'],
+        'name' =>                   ['type' => 'varchar',       'trans' => true,  'required' => 'true'],
         'url' =>                    ['type' => 'varchar',       'required' => 'true'],
-        'h1' =>                     ['type' => 'varchar'],
-        'meta_title' =>             ['type' => 'varchar'],
-        'meta_description' =>       ['type' => 'varchar'],
-        'body' =>                   ['type' => 'text'],
+        'h1' =>                     ['type' => 'varchar',       'trans' => true],
+        'meta_title' =>             ['type' => 'varchar',       'trans' => true],
+        'meta_description' =>       ['type' => 'varchar',       'trans' => true],
+        'body' =>                   ['type' => 'text',          'trans' => true],
         'position' =>               ['type' => 'int',           'def' => 0],
         'enabled' =>                ['type' => 'tinyint',       'def' => 0]
     ];

--- a/hugashop/crm/Extensions/SeoPage/SeoPage.php
+++ b/hugashop/crm/Extensions/SeoPage/SeoPage.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.9
+ * @version 2.0
  *
  */
 
@@ -14,6 +14,7 @@ use HugaShop\Services\Cache;
 use HugaShop\Services\Design;
 use HugaShop\Services\Helper;
 use HugaShop\Services\Request;
+use App\Services\LanguageService;
 use App\Event\DesignBeforeFetchEvent;
 use HugaShop\Extensions\BaseExtension;
 use HugaShop\Extensions\SeoPage\Models\SeoPage as SeoPageModel;
@@ -73,6 +74,9 @@ final class SeoPage extends BaseExtension
     public function page(?int $id = null)
     {
 
+        // Init content language
+        LanguageService::languageCatch();
+
         #### Update
         ###########
         if (!empty($page = Request::getDataAcces(SeoPageModel::getFields()))) {
@@ -96,7 +100,7 @@ final class SeoPage extends BaseExtension
         #### View
         #########
         if (!empty($id)) {
-            $page = SeoPageModel::getOne($id);
+            $page = SeoPageModel::getOneEditTranslate($id);
             if (empty($page->id)) {
                 Request::makeRedirect("/admin/extension/SeoPage");
             }

--- a/hugashop/crm/Extensions/SeoPage/templates/page.tpl
+++ b/hugashop/crm/Extensions/SeoPage/templates/page.tpl
@@ -9,6 +9,8 @@
 
 {block name=content}
 
+        {include 'parts/translation_btn_part.tpl' entity='seo_page'}
+
 	<!-- Основная форма -->
 	<form method="post" enctype="multipart/form-data">
 		<input name="id" type="hidden" value="{$page->id}" />


### PR DESCRIPTION
## Summary
- add translatable fields to SeoPage model
- support language switch in SeoPage controller and template
- integrate SeoPage with OpenAI translations

## Testing
- `php composer.phar validate --no-check-all --strict` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c653f30d883268b1384b8091115f5