### PR TITLE
Add HTMX browsed products block

### DIFF
--- a/assets/grizlicnc/init.js
+++ b/assets/grizlicnc/init.js
@@ -3,7 +3,7 @@
  * Custom javascript code
  * 
  * @author Andri Huga
- * @version 1.5
+ * @version 1.6
  * 
  */
 
@@ -18,6 +18,7 @@ import './js/fancybox/jquery.fancybox.min.js';
 import './js/autocomplete/jquery.autocomplete-min.js';
 import './js/jquery/jquery.form.js';
 import './js/owlcarousel/owl.carousel.min.js';
+import 'https://unpkg.com/htmx.org@1.9.10';
 import './js/bootstrap.bundle.min.js';
 import { getCartInformer, asignFancyAjax, loaderLayer } from './js/common.js';
 

--- a/hugashop/crm/Services/Request.php
+++ b/hugashop/crm/Services/Request.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 3.2
+ * @version 3.3
  *
  * Класс-обертка для обращения к переменным $_GET, $_POST, $_FILES, $_COOKIE, $_SESSION
  *
@@ -581,7 +581,10 @@ class Request
      */
     public static function isAjax(): bool
     {
-        if (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && !empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest') {
+        if (
+            (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && !empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest')
+            || isset($_SERVER['HTTP_HX_REQUEST'])
+        ) {
             return true;
         }
         return false;

--- a/src/Controller/Front/Ajax/BrowsedProductsController.php
+++ b/src/Controller/Front/Ajax/BrowsedProductsController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Controller\Front\Ajax;
+
+use App\Controller\BaseFrontController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+class BrowsedProductsController extends BaseFrontController
+{
+    #[Route('/ajax/browsed-products', name: 'BrowsedProductsBlock', priority: 1)]
+    public function browsedProducts(): Response
+    {
+        return $this->fetchResponse('parts/browsed_products.tpl', 'browsed_products');
+    }
+}

--- a/templates/grizlicnc/parts/browsed_products.tpl
+++ b/templates/grizlicnc/parts/browsed_products.tpl
@@ -1,0 +1,14 @@
+{block name=browsed_products}
+    {get_browsed_products var=browsed_products limit=8}
+
+    {if $browsed_products}
+        <div class="my-5">
+            <div class="h2">{'Вы просматривали'|trans}</div>
+            <ul class="products owl-carousel">
+                {foreach $browsed_products as $product}
+                    {include 'parts/product_item.tpl' type='short'}
+                {/foreach}
+            </ul>
+        </div>
+    {/if}
+{/block}

--- a/templates/grizlicnc/parts/footer.tpl
+++ b/templates/grizlicnc/parts/footer.tpl
@@ -2,18 +2,14 @@
     <div class="container">
 
         <!-- Browsed Product -->
-        {get_browsed_products var=browsed_products limit=8}
-
-        {if $browsed_products}
-            <div class="my-5">
-                <div class="h2">{'Вы просматривали'|trans}</div>
-                <ul class="products owl-carousel">
-                    {foreach $browsed_products as $product}
-                        {include 'parts/product_item.tpl' type='short'}
-                    {/foreach}
-                </ul>
+        <div id="browsed_products"
+             hx-get="{'BrowsedProductsBlock'|linkLang}"
+             hx-trigger="load"
+             hx-swap="outerHTML">
+            <div class="spinner-border" role="status">
+                <span class="visually-hidden">Loading...</span>
             </div>
-        {/if}
+        </div>
 
 
         {* Выбираем в переменную $last_posts последние записи *}

--- a/templates/grizlicnc/parts/head.tpl
+++ b/templates/grizlicnc/parts/head.tpl
@@ -26,7 +26,7 @@
 		<meta name="robots" content="noindex">
 	{/if}
 
-	{importmap point='grizlicnc'}
+        {importmap point='grizlicnc'}
 
 	{block name=head_css}{/block}
 	{block name=head_script}{/block}


### PR DESCRIPTION
## Summary
- enable HX-Request detection in `Request::isAjax`
- load HTMX library in `grizlicnc` theme
- add controller & template for browsed products
- load browsed products via HTMX in footer
- move HTMX script load into `assets/grizlicnc/init.js`

## Testing
- `php -l src/Controller/Front/Ajax/BrowsedProductsController.php` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f305dfeb08326b37597565053bc83