### PR TITLE
Refactor FacebookCommerce extension

### DIFF
--- a/hugashop/crm/Extensions/FacebookCommerce/Controller/FacebookCommerceController.php
+++ b/hugashop/crm/Extensions/FacebookCommerce/Controller/FacebookCommerceController.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.6
+ */
+
+namespace HugaShop\Extensions\FacebookCommerce\Controller;
+
+use HugaShop\Services\Cache;
+use HugaShop\Services\Design;
+use HugaShop\Services\Helper;
+use HugaShop\Services\Request;
+use App\Controller\BaseAdminController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Models\Product\ProductCategory;
+use HugaShop\Extensions\FacebookCommerce\Models\FacebookCommerce as FacebookCommerceModel;
+use HugaShop\Extensions\FacebookCommerce\Models\FacebookCommerceCategory;
+use HugaShop\Extensions\FacebookCommerce\Models\FeedGenerator;
+
+final class FacebookCommerceController extends BaseAdminController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/FacebookCommerce/feed', name: 'ExtFacebookCommerceFeedNew', priority: 20)]
+    #[Route('/FacebookCommerce/feed/{id}', name: 'ExtFacebookCommerceFeed', priority: 20)]
+    public function feed(?int $id = null)
+    {
+        $pricefeed_categories = [];
+
+        #### Update
+        ###########
+        if (!empty($pricefeed = Request::getDataAcces(FacebookCommerceModel::getFields()))) {
+            if (empty($pricefeed->id)) {
+                $pricefeed->token = Helper::makeToken();
+                $pricefeed = Design::setFlashMessage('add', FacebookCommerceModel::createOne($pricefeed));
+            } else {
+                Design::setFlashMessage('update', FacebookCommerceModel::updateOne($pricefeed->id, $pricefeed) >= 0);
+
+                Cache::cache(FeedGenerator::class)->delete('item_' . $pricefeed->id);
+            }
+
+            $pricefeed_categories = Request::post('pricefeed_categories', 'array');
+            FacebookCommerceCategory::setCategories($pricefeed->id, $pricefeed_categories);
+
+            return $this->redirectToRoute('ExtFacebookCommerceFeed', ['id' => $pricefeed->id]);
+        }
+
+        #### View
+        #########
+        if (!empty($id)) {
+            $pricefeed = FacebookCommerceModel::getOne($id);
+
+            if (empty($pricefeed->id)) {
+                return $this->redirectToRoute('ExtFacebookCommerceList');
+            }
+
+            $pricefeed_categories = FacebookCommerceCategory::getCategoriesIds($pricefeed->id);
+        }
+
+        $categories = ProductCategory::getCategoriesTree();
+
+        Design::assign('pricefeed', $pricefeed);
+        Design::assign('categories', $categories);
+        Design::assign('pricefeed_categories', $pricefeed_categories);
+
+        return $this->fetchExtResponse('feed.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/FacebookCommerce/Controller/FacebookCommerceListController.php
+++ b/hugashop/crm/Extensions/FacebookCommerce/Controller/FacebookCommerceListController.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.6
+ */
+
+namespace HugaShop\Extensions\FacebookCommerce\Controller;
+
+use HugaShop\Services\Cache;
+use HugaShop\Services\Design;
+use HugaShop\Services\Helper;
+use HugaShop\Services\Request;
+use App\Controller\BaseAdminController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Extensions\FacebookCommerce\Models\FacebookCommerce as FacebookCommerceModel;
+use HugaShop\Extensions\FacebookCommerce\Models\FeedGenerator;
+
+final class FacebookCommerceListController extends BaseAdminController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/FacebookCommerce', name: 'ExtFacebookCommerceList', priority: 20)]
+    public function index()
+    {
+        if (Request::checkCSRF()) {
+            $ids = Request::post('check');
+            if (is_array($ids)) {
+                switch (Request::post('action')) {
+                    case 'delete':
+                        FacebookCommerceModel::deleteOne($ids);
+                        break;
+                }
+            }
+
+            foreach (Helper::getPositions() as $id => $position) {
+                FacebookCommerceModel::updateOne($id, ['position' => $position]);
+            }
+
+            Cache::cache(FeedGenerator::class)->clear();
+        }
+
+        $pricefeeds = FacebookCommerceModel::getList(order: 'position');
+        Design::assign('pricefeeds', $pricefeeds);
+
+        return $this->fetchExtResponse('feed_list.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/FacebookCommerce/FacebookCommerce.php
+++ b/hugashop/crm/Extensions/FacebookCommerce/FacebookCommerce.php
@@ -4,117 +4,22 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.5
+ * @version 1.6
  *
  */
 
 namespace HugaShop\Extensions\FacebookCommerce;
 
-use HugaShop\Services\Cache;
-use HugaShop\Services\Design;
-use HugaShop\Services\Helper;
-use HugaShop\Services\Request;
 use HugaShop\Extensions\BaseExtension;
-use HugaShop\Models\Product\ProductCategory;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Encoder\CsvEncoder;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use HugaShop\Extensions\FacebookCommerce\Models\FeedGenerator;
-use HugaShop\Extensions\FacebookCommerce\Models\FacebookCommerceCategory;
 use HugaShop\Extensions\FacebookCommerce\Models\FacebookCommerce as FacebookCommerceModel;
 
 final class FacebookCommerce extends BaseExtension
 {
-
-    /**
-     * Список
-     */
-    public function index()
-    {
-
-        // Обработка действий
-        if (Request::checkCSRF()) {
-
-            // Действия с выбранными
-            $ids = Request::post('check');
-            if (is_array($ids)) {
-                switch (Request::post('action')) {
-                    case 'delete': {
-                            FacebookCommerceModel::deleteOne($ids);
-                            break;
-                        }
-                }
-            }
-
-            foreach (Helper::getPositions() as $id => $position) {
-                FacebookCommerceModel::updateOne($id, ['position' => $position]);
-            }
-
-            Cache::cache(FeedGenerator::class)->clear();
-        }
-
-        $pricefeeds = FacebookCommerceModel::getList(order: 'position');
-        Design::assign('pricefeeds', $pricefeeds);
-
-        return $this->getTemplatePath('templates/feed_list.tpl');
-    }
-
-
-    /**
-     * Pricelist
-     * @param ?int $pricefeed_id
-     */
-    public function feed(?int $pricefeed_id = null)
-    {
-
-        $pricefeed_categories = [];
-
-        #### Update
-        ###########
-        if (!empty($pricefeed = Request::getDataAcces(FacebookCommerceModel::getFields()))) {
-            if (empty($pricefeed->id)) {
-                $pricefeed->token = Helper::makeToken();
-                $pricefeed = Design::setFlashMessage('add', FacebookCommerceModel::createOne($pricefeed));
-            } else {
-                Design::setFlashMessage('update', FacebookCommerceModel::updateOne($pricefeed->id, $pricefeed) >= 0);
-
-                // Cache clean
-                Cache::cache(FeedGenerator::class)->delete('item_' . $pricefeed->id);
-            }
-
-            $pricefeed_categories = Request::post('pricefeed_categories', 'array');
-            FacebookCommerceCategory::setCategories($pricefeed->id, $pricefeed_categories);
-
-            // Делаем редирект на страницу с ID
-            Request::makeRedirect("/admin/extension/" . self::getName() . "/feed/$pricefeed->id");
-        }
-
-
-        #### View
-        #########
-        if (!empty($pricefeed_id)) {
-
-            $pricefeed = FacebookCommerceModel::getOne($pricefeed_id);
-
-            if (empty($pricefeed->id)) {
-                Request::makeRedirect("/admin/extension/" . self::getName());
-            }
-
-            $pricefeed_categories = FacebookCommerceCategory::getCategoriesIds($pricefeed->id);
-        }
-
-        $categories = ProductCategory::getCategoriesTree();
-
-        Design::assign('pricefeed', $pricefeed);
-        Design::assign('categories', $categories);
-        Design::assign('pricefeed_categories', $pricefeed_categories);
-
-        // Проверим сущестование файла
-        return $this->getTemplatePath('templates/feed.tpl');
-    }
-
-
     /**
      * Webhook module
      * @param array $params


### PR DESCRIPTION
## Summary
- migrate FacebookCommerce extension to controller-based structure
- keep webhook logic in main class

## Testing
- `php -l hugashop/crm/Extensions/FacebookCommerce/FacebookCommerce.php`
- `php -l hugashop/crm/Extensions/FacebookCommerce/Controller/FacebookCommerceListController.php`
- `php -l hugashop/crm/Extensions/FacebookCommerce/Controller/FacebookCommerceController.php`


------
https://chatgpt.com/codex/tasks/task_e_687169459ef08326b59955155552523a