### PR TITLE
Refactor ProductFilling extension with controller

### DIFF
--- a/hugashop/crm/Extensions/ProductFilling/Controller/ProductFillingController.php
+++ b/hugashop/crm/Extensions/ProductFilling/Controller/ProductFillingController.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.6
+ */
+
+namespace HugaShop\Extensions\ProductFilling\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Request;
+use App\Services\PaginationService;
+use App\Controller\BaseAdminController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Models\Product\ProductCategory;
+use HugaShop\Extensions\ProductFilling\Models\Product;
+use HugaShop\Extensions\ProductFilling\Services\Calculate;
+use HugaShop\Models\Localization\Language;
+
+final class ProductFillingController extends BaseAdminController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/ProductFilling', name: 'ExtProductFilling', priority: 20)]
+    public function index()
+    {
+        $filter = PaginationService::initFilter();
+
+        $category_id = Request::getInt('category_id');
+        $filter['category_id'] = $category_id;
+        if ($category_id && ($category = ProductCategory::getCategoryById($category_id))) {
+            $filter['category_id'] = $category->children;
+            Design::assign('category', $category);
+        }
+
+        if ($keyword = Request::get('keyword')) {
+            $filter['keyword'] = $keyword;
+            Design::assign('keyword', $keyword);
+        }
+
+        $filling = Request::getInt('filling');
+        if (!is_null($filling)) {
+            $filter['filling'] = max(0, min(100, $filling));
+        }
+
+        $products       = Product::getProducts($filter, join: ['image', 'fillings']);
+        $products_count = Product::countProducts($filter);
+        $categories     = ProductCategory::getCategoriesTree();
+
+        Design::assign('categories', $categories);
+        Design::assign('products', $products);
+        Design::assign('products_count', $products_count);
+        Design::assign('filling', $filter['filling'] ?? 100);
+        Design::assign('languages', Language::getLanguages());
+        Design::assign('pagination', PaginationService::getPagination($products_count, $filter));
+        Design::assign('extension', $this->getExtension());
+
+        return $this->fetchExtResponse('product_list.tpl');
+    }
+
+    #[Route('/ProductFilling/ajax/calculate', name: 'ExtProductFillingCalculate', priority: 20)]
+    public function calculate()
+    {
+        $batch = 20;
+        $from = max(0, Request::getInt('from'));
+        $filter = [
+            'limit' => $batch,
+            'page'  => intdiv($from, $batch) + 1,
+        ];
+
+        $products = Product::getProducts($filter);
+        foreach ($products as $product) {
+            Calculate::calculateProduct($product->id);
+        }
+
+        $total = Product::countProducts();
+        $processed = $from + $products->count();
+
+        return (object) [
+            'from'  => $processed,
+            'total' => $total,
+            'end'   => $processed >= $total,
+        ];
+    }
+
+    #[Route('/ProductFilling/ajax/calculateProduct', name: 'ExtProductFillingCalculateProduct', priority: 20)]
+    public function calculateProduct()
+    {
+        if (!Request::checkCSRF()) {
+            return ['error' => 'csrf'];
+        }
+
+        $id = Request::postInt('id');
+        if (empty($id)) {
+            return ['error' => 'id'];
+        }
+
+        Calculate::calculateProduct($id);
+
+        if ($product = Product::getProduct($id, ['fillings'])) {
+            $result = [];
+            foreach ($product->fillings as $fill) {
+                $result[$fill->language_code] = $fill->percent;
+            }
+            return $result;
+        }
+
+        return [];
+    }
+}

--- a/hugashop/crm/Extensions/ProductFilling/ProductFilling.php
+++ b/hugashop/crm/Extensions/ProductFilling/ProductFilling.php
@@ -2,120 +2,15 @@
 
 /**
  * HugaShop - Sell anything
- * 
+ *
  * @author Andri Huga
- * @version 1.5
- * 
+ * @version 1.6
+ *
  * Extension calculates content filling percent for products
  */
 
 namespace HugaShop\Extensions\ProductFilling;
 
-use HugaShop\Services\Design;
-use HugaShop\Services\Request;
-use App\Services\PaginationService;
 use HugaShop\Extensions\BaseExtension;
-use HugaShop\Models\Product\ProductCategory;
-use HugaShop\Extensions\ProductFilling\Models\Product;
-use HugaShop\Extensions\ProductFilling\Services\Calculate;
-use HugaShop\Models\Localization\Language;
 
-final class ProductFilling extends BaseExtension
-{
-
-
-    /**
-     * Show products with filling percent
-     */
-    public function index()
-    {
-
-        $filter = PaginationService::initFilter();
-
-        $category_id = Request::getInt('category_id');
-        $filter['category_id'] = $category_id;
-        if ($category_id && ($category = ProductCategory::getCategoryById($category_id))) {
-            $filter['category_id'] = $category->children;
-            Design::assign('category', $category);
-        }
-
-        if ($keyword = Request::get('keyword')) {
-            $filter['keyword'] = $keyword;
-            Design::assign('keyword', $keyword);
-        }
-
-        $filling = Request::getInt('filling');
-        if (!is_null($filling)) {
-            $filter['filling'] = max(0, min(100, $filling));
-        }
-
-        $products       = Product::getProducts($filter, join: ['image', 'fillings']);
-        $products_count = Product::countProducts($filter);
-        $categories     = ProductCategory::getCategoriesTree();
-
-        Design::assign('categories', $categories);
-        Design::assign('products', $products);
-        Design::assign('products_count', $products_count);
-        Design::assign('filling', $filter['filling'] ?? 100);
-        Design::assign('languages', Language::getLanguages());
-        Design::assign('pagination', PaginationService::getPagination($products_count, $filter));
-
-        return $this->getTemplatePath('templates/product_list.tpl');
-    }
-
-
-    /**
-     * Recalculate products filling. Ajax
-     */
-    public function calculate()
-    {
-        $batch = 20;
-        $from = max(0, Request::getInt('from'));
-        $filter = [
-            'limit' => $batch,
-            'page'  => intdiv($from, $batch) + 1
-        ];
-
-        $products = Product::getProducts($filter);
-        foreach ($products as $product) {
-            Calculate::calculateProduct($product->id);
-        }
-
-        $total = Product::countProducts();
-        $processed = $from + $products->count();
-
-        return (object) [
-            'from'  => $processed,
-            'total' => $total,
-            'end'   => $processed >= $total,
-        ];
-    }
-
-
-    /**
-     * Recalculate filling for one product. Ajax
-     */
-    public function calculateProduct()
-    {
-        if (!Request::checkCSRF()) {
-            return ['error' => 'csrf'];
-        }
-
-        $id = Request::postInt('id');
-        if (empty($id)) {
-            return ['error' => 'id'];
-        }
-
-        Calculate::calculateProduct($id);
-
-        if ($product = Product::getProduct($id, ['fillings'])) {
-            $result = [];
-            foreach ($product->fillings as $fill) {
-                $result[$fill->language_code] = $fill->percent;
-            }
-            return $result;
-        }
-
-        return [];
-    }
-}
+final class ProductFilling extends BaseExtension {}


### PR DESCRIPTION
## Summary
- adapt ProductFilling extension to new controller-based structure
- create `ProductFillingController` for listing and ajax actions
- simplify `ProductFilling` class

## Testing
- `php -l hugashop/crm/Extensions/ProductFilling/Controller/ProductFillingController.php`
- `php -l hugashop/crm/Extensions/ProductFilling/ProductFilling.php`
- `composer validate --no-check-all --strict` *(fails: name and description required)*

------
https://chatgpt.com/codex/tasks/task_e_6871969e5b7c832689ce07205d74644e