### PR TITLE
Refactor RedirectUrl extension using controller structure

### DIFF
--- a/hugashop/crm/Extensions/RedirectUrl/Controller/RedirectUrlController.php
+++ b/hugashop/crm/Extensions/RedirectUrl/Controller/RedirectUrlController.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.8
+ *
+ */
+
+namespace HugaShop\Extensions\RedirectUrl\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Request;
+use App\Controller\BaseAdminController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Extensions\RedirectUrl\Models\RedirectUrl;
+
+final class RedirectUrlController extends BaseAdminController
+{
+    use BaseExtensionTrait;
+
+    /**
+     * Link edit
+     */
+    #[Route('/RedirectUrl/link', name: 'ExtRedirectUrlNew', priority: 20)]
+    #[Route('/RedirectUrl/link/{id}', name: 'ExtRedirectUrl', priority: 20)]
+    public function link(?int $id = null)
+    {
+        #### Update
+        ###########
+        if (!empty($link = Request::getDataAcces(RedirectUrl::getFields()))) {
+            if (empty($link->id)) {
+                $link = Design::setFlashMessage('add', RedirectUrl::createOne($link));
+            } else {
+                Design::setFlashMessage('update', RedirectUrl::updateOne($link->id, $link));
+            }
+
+            RedirectUrl::cacheClear();
+
+            return $this->redirectToRoute('ExtRedirectUrl', ['id' => $link->id]);
+        }
+
+        #### View
+        #########
+        if (!empty($id)) {
+            $link = RedirectUrl::getOne($id);
+            if (empty($link->id)) {
+                return $this->redirectToRoute('ExtRedirectUrlList');
+            }
+        }
+
+        Design::assign('link', $link);
+
+        return $this->fetchExtResponse('link.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/RedirectUrl/Controller/RedirectUrlListController.php
+++ b/hugashop/crm/Extensions/RedirectUrl/Controller/RedirectUrlListController.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.8
+ *
+ */
+
+namespace HugaShop\Extensions\RedirectUrl\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Request;
+use App\Controller\BaseAdminController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Extensions\RedirectUrl\Models\RedirectUrl;
+
+final class RedirectUrlListController extends BaseAdminController
+{
+    use BaseExtensionTrait;
+
+    /**
+     * Url list
+     */
+    #[Route('/RedirectUrl', name: 'ExtRedirectUrlList', priority: 20)]
+    public function links()
+    {
+        // Handle actions
+        if (Request::checkCSRF()) {
+            $ids = Request::post('check');
+            if (is_array($ids)) {
+                switch (Request::post('action')) {
+                    case 'disable':
+                        RedirectUrl::updateOne($ids, ['enabled' => 0]);
+                        break;
+                    case 'enable':
+                        RedirectUrl::updateOne($ids, ['enabled' => 1]);
+                        break;
+                    case 'delete':
+                        foreach ($ids as $id) {
+                            RedirectUrl::deleteOne($id);
+                        }
+                        break;
+                }
+            }
+            RedirectUrl::cacheClear();
+        }
+
+        $links = RedirectUrl::getList();
+        Design::assign('links', $links);
+
+        return $this->fetchExtResponse('link_list.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/RedirectUrl/RedirectUrl.php
+++ b/hugashop/crm/Extensions/RedirectUrl/RedirectUrl.php
@@ -4,83 +4,14 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.7
+ * @version 1.8
  *
  */
 
 namespace HugaShop\Extensions\RedirectUrl;
 
-use HugaShop\Services\Design;
-use HugaShop\Services\Request;
 use HugaShop\Extensions\BaseExtension;
-use HugaShop\Extensions\RedirectUrl\Models\RedirectUrl as RedirectUrlModel;
 
 final class RedirectUrl extends BaseExtension
 {
-
-    /**
-     * Url List
-     */
-    public function index()
-    {
-        if (Request::checkCSRF()) {
-            $ids = Request::post('check');
-            if (is_array($ids)) {
-                switch (Request::post('action')) {
-                    case 'disable':
-                        RedirectUrlModel::updateOne($ids, ['enabled' => 0]);
-                        break;
-                    case 'enable':
-                        RedirectUrlModel::updateOne($ids, ['enabled' => 1]);
-                        break;
-                    case 'delete':
-                        foreach ($ids as $id) {
-                            RedirectUrlModel::deleteOne($id);
-                        }
-                        break;
-                }
-            }
-
-            RedirectUrlModel::cacheClear(); # Cache clean
-        }
-
-        $links = RedirectUrlModel::getList();
-        Design::assign('links', $links);
-
-        return $this->getTemplatePath('templates/link_list.tpl');
-    }
-
-
-    /**
-     * link
-     */
-    public function link(?int $id = null)
-    {
-
-        #### Update
-        ###########
-        if (!empty($link = Request::getDataAcces(RedirectUrlModel::getFields()))) {
-            if (empty($link->id)) {
-                $link = Design::setFlashMessage('add', RedirectUrlModel::createOne($link));
-            } else {
-                Design::setFlashMessage('update', RedirectUrlModel::updateOne($link->id, $link));
-            }
-
-            RedirectUrlModel::cacheClear(); # Cache clean
-            Request::makeRedirect("/admin/extension/RedirectUrl/link/$link->id");
-        }
-
-
-        #### View
-        #########
-        if (!empty($id)) {
-            $link = RedirectUrlModel::getOne($id);
-            if (empty($link->id)) {
-                Request::makeRedirect('/admin/extension/RedirectUrl');
-            }
-        }
-
-        Design::assign('link', $link);
-        return $this->getTemplatePath('templates/link.tpl');
-    }
 }


### PR DESCRIPTION
## Summary
- migrate RedirectUrl extension to controller-based structure
- add `RedirectUrlController` and `RedirectUrlListController`
- simplify the extension class

## Testing
- `php -l hugashop/crm/Extensions/RedirectUrl/Controller/RedirectUrlController.php`
- `composer dump-autoload`

------
https://chatgpt.com/codex/tasks/task_e_687196dd7d7c8326aa13228f311235e3