### PR TITLE
Refactor SeoLinker extension

### DIFF
--- a/hugashop/crm/Extensions/SeoLinker/Controller/SeoLinkerController.php
+++ b/hugashop/crm/Extensions/SeoLinker/Controller/SeoLinkerController.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ *
+ */
+
+namespace HugaShop\Extensions\SeoLinker\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Request;
+use App\Controller\BaseAdminController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Extensions\SeoLinker\Models\SeoLinkerLink;
+use HugaShop\Extensions\SeoLinker\Models\SeoLinker as SeoLinkerModel;
+
+final class SeoLinkerController extends BaseAdminController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/SeoLinker/page/{id}', requirements: ['id' => '\\d+'], name: 'ExtSeoLinkerPage', priority: 20)]
+    public function page(int $id)
+    {
+        $this->checkAdminAccess('extension');
+
+        $page = SeoLinkerModel::getOne($id);
+        if (empty($page)) {
+            return $this->redirectToRoute('ExtSeoLinker');
+        }
+
+        $links = SeoLinkerLink::getList(['from_url' => $page->url]);
+
+        $links_in = SeoLinkerLink::getList([
+            'to_url' => $page->url,
+            'type'   => 'internal',
+        ]);
+
+        foreach ($links_in as $ln) {
+            $src = SeoLinkerModel::getOne(['url' => $ln->from_url]);
+            $ln->from_id = $src->id ?? null;
+        }
+
+        Design::assign('page', $page);
+        Design::assign('links', $links);
+        Design::assign('links_in', $links_in);
+        Design::assign('extension', $this->getExtension());
+
+        return $this->fetchExtResponse('page.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/SeoLinker/Controller/SeoLinkerListController.php
+++ b/hugashop/crm/Extensions/SeoLinker/Controller/SeoLinkerListController.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ *
+ */
+
+namespace HugaShop\Extensions\SeoLinker\Controller;
+
+use HugaShop\Services\Config;
+use HugaShop\Services\Design;
+use HugaShop\Services\Request;
+use App\Services\PaginationService;
+use App\Controller\BaseAdminController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Extensions\SeoLinker\SeoLinker;
+use HugaShop\Extensions\SeoLinker\Services\ScanBatch;
+use HugaShop\Extensions\SeoLinker\Models\SeoLinkerLink;
+use HugaShop\Extensions\SeoLinker\Models\SeoLinker as SeoLinkerModel;
+
+final class SeoLinkerListController extends BaseAdminController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/SeoLinker', name: 'ExtSeoLinker', priority: 20)]
+    public function index()
+    {
+        $this->checkAdminAccess('extension');
+
+        $base_url = SeoLinker::getSettings('base_url') ?? rtrim(Config::get('root_url'), '/') . '/';
+
+        if (Request::post('scan')) {
+            if (Request::post('start')) {
+                SeoLinkerModel::query()->delete();
+                SeoLinkerLink::query()->delete();
+            }
+
+            [$scanned, $pending] = ScanBatch::scanBatch(
+                $base_url,
+                limit: 1,
+                delay: SeoLinker::getSettings('delay')
+            );
+
+            if (Request::isAjax()) {
+                return new JsonResponse([
+                    'scanned' => $scanned,
+                    'pending' => $pending,
+                ]);
+            }
+        }
+
+        $filter = PaginationService::initFilter();
+        $pages = SeoLinkerModel::getList($filter, order: ['in_internal', 'desc']);
+        $pages_count = SeoLinkerModel::getCount();
+
+        Design::assign('pagination', PaginationService::getPagination($pages_count, $filter));
+        Design::assign('pages', $pages);
+        Design::assign('pages_total', $pages_count);
+        Design::assign('extension', $this->getExtension());
+
+        return $this->fetchExtResponse('report.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/SeoLinker/SeoLinker.php
+++ b/hugashop/crm/Extensions/SeoLinker/SeoLinker.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.7
+ * @version 1.8
  * 
  * SeoLinker extension
  * @link https://github.com/spatie/crawler
@@ -13,90 +13,6 @@
 
 namespace HugaShop\Extensions\SeoLinker;
 
-use HugaShop\Services\Config;
-use HugaShop\Services\Design;
-use HugaShop\Services\Request;
-use App\Services\PaginationService;
 use HugaShop\Extensions\BaseExtension;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use HugaShop\Extensions\SeoLinker\Services\ScanBatch;
-use HugaShop\Extensions\SeoLinker\Models\SeoLinkerLink;
-use HugaShop\Extensions\SeoLinker\Models\SeoLinker as SeoLinkerModel;
 
-final class SeoLinker extends BaseExtension
-{
-
-    /**
-     * Show links report
-     */
-    public function index()
-    {
-
-        $base_url = self::getSettings('base_url') ?? rtrim(Config::get('root_url'), '/') . '/';
-
-        if (Request::post('scan')) {
-
-            if (Request::post('start')) {
-                SeoLinkerModel::query()->delete();
-                SeoLinkerLink::query()->delete();
-            }
-
-            [$scanned, $pending] = ScanBatch::scanBatch(
-                $base_url,
-                limit: 1,
-                delay: self::getSettings('delay')
-            );
-
-            if (Request::isAjax()) {
-                return new JsonResponse([
-                    'scanned' => $scanned,
-                    'pending' => $pending,
-                ]);
-            }
-        }
-
-        $filter         = PaginationService::initFilter();
-        $pages          = SeoLinkerModel::getList($filter, order: ['in_internal', 'desc']);
-        $pages_count    = SeoLinkerModel::getCount();
-
-        Design::assign('pagination', PaginationService::getPagination($pages_count, $filter));
-        Design::assign('pages', $pages);
-        Design::assign('pages_total', $pages_count);
-
-        return $this->getTemplatePath('templates/report.tpl');
-    }
-
-
-    /** 
-     * Page view
-     */
-    public function page(?int $id = null)
-    {
-        if (empty($id)) {
-            Request::makeRedirect('/admin/extension/SeoLinker');
-        }
-
-        $page = SeoLinkerModel::getOne($id);
-        if (empty($page)) {
-            Request::makeRedirect('/admin/extension/SeoLinker');
-        }
-
-        $links = SeoLinkerLink::getList(['from_url' => $page->url]);
-
-        $links_in = SeoLinkerLink::getList([
-            'to_url' => $page->url,
-            'type'   => 'internal',
-        ]);
-
-        foreach ($links_in as $ln) {
-            $src = SeoLinkerModel::getOne(['url' => $ln->from_url]);
-            $ln->from_id = $src->id ?? null;
-        }
-
-        Design::assign('page', $page);
-        Design::assign('links', $links);
-        Design::assign('links_in', $links_in);
-
-        return $this->getTemplatePath('templates/page.tpl');
-    }
-}
+final class SeoLinker extends BaseExtension {}

--- a/hugashop/crm/Extensions/SeoLinker/settings.yaml
+++ b/hugashop/crm/Extensions/SeoLinker/settings.yaml
@@ -3,4 +3,4 @@ description: "Анализ внутренних ссылок сайта"
 settings_params:
   - { variable: base_url, name: "Стартовая страница сканирования" }
   - { variable: delay, name: "Задержка сканирования, мсек.", default: 0 }
-version: 1.2
+version: 1.3


### PR DESCRIPTION
## Summary
- convert SeoLinker extension to controller based structure
- add list and page controllers
- bump extension versions

## Testing
- `composer validate --no-check-all`
- `php -l hugashop/crm/Extensions/SeoLinker/SeoLinker.php`
- `php -l hugashop/crm/Extensions/SeoLinker/Controller/SeoLinkerListController.php`
- `php -l hugashop/crm/Extensions/SeoLinker/Controller/SeoLinkerController.php`


------
https://chatgpt.com/codex/tasks/task_e_687196f91798832686f7fed18d731de5