### PR TITLE
Add comment photo management in admin

### DIFF
--- a/src/Controller/Admin/Content/CommentController.php
+++ b/src/Controller/Admin/Content/CommentController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.4
+ * @version 2.5
  *
  */
 
@@ -14,6 +14,7 @@ use HugaShop\Services\Design;
 use HugaShop\Services\Helper;
 use HugaShop\Services\Request;
 use HugaShop\Models\Content\ContentComment;
+use App\Services\ImageService;
 use App\Controller\BaseAdminController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -33,6 +34,8 @@ class CommentController extends BaseAdminController
             $comment->date = Helper::dateConvert($comment->date . ' ' . Request::post('time', 'string'), 'Y-m-d H:i:s');
             Design::setFlashMessage('update', ContentComment::updateOne($comment->id, $comment));
 
+            ImageService::catchImages($comment->id, 'comment', 'images');
+
             return $this->redirectToRoute('CommentAdmin', ['id' => $comment->id]);
         }
 
@@ -40,7 +43,7 @@ class CommentController extends BaseAdminController
         #### View
         #########
         if (!empty($id)) {
-            $comment = ContentComment::getOne($id, ['user', 'entity']);
+            $comment = ContentComment::getOne($id, ['user', 'entity', 'images']);
             
             if (empty($comment->id)) {
                 return $this->redirectToRoute('CommentsAdmin');

--- a/templates/admin/content/comment.tpl
+++ b/templates/admin/content/comment.tpl
@@ -67,6 +67,11 @@
                 </div>
             </div>
 
+            <div class="col-lg-6 layer">
+                <h2>Фотографии</h2>
+                {include file='parts\\image_upload_part.tpl' images=$comment->images can_edit=true}
+            </div>
+
         </div>
     </form>
 


### PR DESCRIPTION
## Summary
- handle comment images in admin controller
- display photo list and upload widget for comments

## Testing
- `php -l src/Controller/Admin/Content/CommentController.php`
- `composer validate --no-check-all --strict`

------
https://chatgpt.com/codex/tasks/task_e_68757b61fa748326a12a640e665bdf43