### PR TITLE
Update feature selection logic

### DIFF
--- a/src/Controller/Admin/Ajax/ProductAjax.php
+++ b/src/Controller/Admin/Ajax/ProductAjax.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.4
+ * @version 2.5
  *
  */
 
@@ -100,11 +100,15 @@ class ProductAjax extends BaseAdminController
         $keyword        = Request::input('query', 'string');
 
         $features       = ProductFeature::getListTranslate(['search' => $keyword, 'limit' => $limit]);
-        $features_name  = $features?->pluck('name');
+
+        $suggestions = [];
+        foreach ($features as $feature) {
+            $suggestions[] = ['value' => $feature->name, 'data' => $feature->id];
+        }
 
         $res = new \stdClass();
         $res->query = $keyword;
-        $res->suggestions = $features_name;
+        $res->suggestions = $suggestions;
 
         return new JsonResponse($res);
     }

--- a/templates/admin/product/product.tpl
+++ b/templates/admin/product/product.tpl
@@ -230,11 +230,12 @@
 
 							for (let i = 0; i < data.length; i++) {
 								let feature = data[i];
-								let new_line = line.clone(true);
+                                                                let new_line = line.clone(true);
 
-								new_line.find("label.col-form-label").text(feature.name);
-								new_line.find("input").attr('name', "options[" + feature.id + "]").
-								val(feature.value);
+                                                                new_line.attr('feature_id', feature.id);
+                                                                new_line.find("label.col-form-label").text(feature.name);
+                                                                new_line.find("input").attr('name', "options[" + feature.id + "]").
+                                                                val(feature.value);
 
 								new_line.appendTo('ul.features').find("input")
 									.autocomplete({
@@ -273,19 +274,35 @@
 
 
 				// Автозаполнение названия характеристик
-				$('.features').on('focus', 'input[name*=new_features_names]', function(index) {
-					$(this).autocomplete({
-						serviceUrl: '/admin/ajax/product/get_feature_name',
-						type: 'POST',
-						minChars: 0,
-						params: {
-							product_id: product_id,
-							lang: lang_code,
-							csrf: csrf
-						},
-						noCache: false
-					});
-				});
+                                $('.features').on('focus', 'input[name*=new_features_names]', function(index) {
+                                        let $nameInput = $(this);
+                                        $nameInput.autocomplete({
+                                                serviceUrl: '/admin/ajax/product/get_feature_name',
+                                                type: 'POST',
+                                                minChars: 0,
+                                                params: {
+                                                        product_id: product_id,
+                                                        lang: lang_code,
+                                                        csrf: csrf
+                                                },
+                                                noCache: false,
+                                                onSelect: function(suggestion) {
+                                                        let $line = $nameInput.closest('li');
+                                                        $line.attr('feature_id', suggestion.data);
+                                                        $line.find('input[name*=new_features_values]').autocomplete({
+                                                                serviceUrl: '/admin/ajax/product/get_option',
+                                                                type: 'POST',
+                                                                minChars: 0,
+                                                                params: {
+                                                                        feature_id: suggestion.data,
+                                                                        lang: lang_code,
+                                                                        csrf: csrf
+                                                                },
+                                                                noCache: false
+                                                        });
+                                                }
+                                        });
+                                });
 
 
 				// Добавление нового свойства товара


### PR DESCRIPTION
## Summary
- return feature IDs from `get_feature_name`
- populate `feature_id` attribute when adding features
- load option suggestions for new features

## Testing
- `composer validate --no-check-publish`

------
https://chatgpt.com/codex/tasks/task_e_6877551c6ac88326b533ceac2c97630b