### PR TITLE
Log product search keywords

### DIFF
--- a/hugashop/crm/Extensions/ProductSearchKeyword/Controller/ProductSearchKeywordListController.php
+++ b/hugashop/crm/Extensions/ProductSearchKeyword/Controller/ProductSearchKeywordListController.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\ProductSearchKeyword\Controller;
+
+use HugaShop\Services\Design;
+use App\Services\PaginationService;
+use App\Controller\BaseAdminController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Extensions\ProductSearchKeyword\Models\ProductSearchKeyword;
+
+final class ProductSearchKeywordListController extends BaseAdminController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/ProductSearchKeyword', name: 'ExtProductSearchKeywordList', priority: 20)]
+    public function index()
+    {
+        $this->checkAdminAccess('extension');
+
+        $filter         = PaginationService::initFilter();
+        $keywords       = ProductSearchKeyword::getList($filter, order: ['created_at', 'desc']);
+        $keywords_count = ProductSearchKeyword::getCount();
+
+        Design::assign('keywords',    $keywords);
+        Design::assign('pagination',  PaginationService::getPagination($keywords_count, $filter));
+        Design::assign('extension',   $this->getExtension());
+        Design::assign('meta_title',  'Поисковые запросы');
+
+        return $this->fetchExtResponse('list.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/ProductSearchKeyword/EventListener/ProductSearchEventListener.php
+++ b/hugashop/crm/Extensions/ProductSearchKeyword/EventListener/ProductSearchEventListener.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\ProductSearchKeyword\EventListener;
+
+use App\Event\ProductSearchEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use HugaShop\Extensions\BaseExtensionTrait;
+use HugaShop\Extensions\ProductSearchKeyword\Models\ProductSearchKeyword;
+
+class ProductSearchEventListener
+{
+    use BaseExtensionTrait;
+
+    #[AsEventListener]
+    public function onProductSearchEvent(ProductSearchEvent $event): void
+    {
+        if (empty($this->getSettings()->enabled)) {
+            return;
+        }
+
+        ProductSearchKeyword::logKeyword($event->getQuery());
+    }
+}

--- a/hugashop/crm/Extensions/ProductSearchKeyword/Models/ProductSearchKeyword.php
+++ b/hugashop/crm/Extensions/ProductSearchKeyword/Models/ProductSearchKeyword.php
@@ -1,32 +1,31 @@
 <?php
-
 /**
  * HugaShop - Sell anything
  *
  * @author Andri Huga
  * @version 1.0
- *
  */
 
-namespace HugaShop\Models;
+namespace HugaShop\Extensions\ProductSearchKeyword\Models;
 
-use HugaShop\Models\BaseModel;
+use HugaShop\Extensions\BaseExtensionModel;
 
-class ProductSearchKeyword extends BaseModel
+final class ProductSearchKeyword extends BaseExtensionModel
 {
     protected static $table_fields = [
-        'id' =>         ['type' => 'int',      'extra' => 'AUTO_INCREMENT'],
-        'name' =>       ['type' => 'varchar'],
+        'id'         => ['type' => 'int',      'extra' => 'AUTO_INCREMENT'],
+        'name'       => ['type' => 'varchar'],
         'created_at' => ['type' => 'datetime', 'def' => 'CURRENT_TIMESTAMP'],
     ];
 
     public static function logKeyword(string $keyword): void
     {
-        if (trim($keyword) === '') {
+        $keyword = trim($keyword);
+        if ($keyword === '') {
             return;
         }
         self::createOne([
-            'name' => trim($keyword),
+            'name'       => $keyword,
             'created_at' => date('Y-m-d H:i:s'),
         ]);
     }

--- a/hugashop/crm/Extensions/ProductSearchKeyword/ProductSearchKeyword.php
+++ b/hugashop/crm/Extensions/ProductSearchKeyword/ProductSearchKeyword.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\ProductSearchKeyword;
+
+use HugaShop\Extensions\BaseExtension;
+
+final class ProductSearchKeyword extends BaseExtension {}

--- a/hugashop/crm/Extensions/ProductSearchKeyword/settings.yaml
+++ b/hugashop/crm/Extensions/ProductSearchKeyword/settings.yaml
@@ -1,0 +1,5 @@
+name: "Поисковые запросы"
+description: "Сохраняет поисковые запросы пользователей"
+settings_params:
+  - { variable: enabled, name: "Включено", options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }], default: 1 }
+version: 1.0

--- a/hugashop/crm/Extensions/ProductSearchKeyword/templates/list.tpl
+++ b/hugashop/crm/Extensions/ProductSearchKeyword/templates/list.tpl
@@ -1,0 +1,24 @@
+{extends 'wrapper/main.tpl'}
+{include 'extension/parts/menu_part.tpl'}
+
+{$meta_title='Поисковые запросы'}
+
+{block name=content}
+    <div class="header_top">
+        <h1>{$meta_title}</h1>
+    </div>
+    <div id="main_list">
+        {if $keywords}
+            {include file='parts/pagination.tpl'}
+            <div class="list">
+                {foreach $keywords as $k}
+                    <div class="list_row">
+                        <div class="col-8 text-break">{$k->name}</div>
+                        <div class="col-4 text-end">{$k->created_at|date} {$k->created_at|time}</div>
+                    </div>
+                {/foreach}
+            </div>
+            {include file='parts/pagination.tpl'}
+        {/if}
+    </div>
+{/block}

--- a/hugashop/crm/Models/ProductSearchKeyword.php
+++ b/hugashop/crm/Models/ProductSearchKeyword.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ *
+ */
+
+namespace HugaShop\Models;
+
+use HugaShop\Models\BaseModel;
+
+class ProductSearchKeyword extends BaseModel
+{
+    protected static $table_fields = [
+        'id' =>         ['type' => 'int',      'extra' => 'AUTO_INCREMENT'],
+        'name' =>       ['type' => 'varchar'],
+        'created_at' => ['type' => 'datetime', 'def' => 'CURRENT_TIMESTAMP'],
+    ];
+
+    public static function logKeyword(string $keyword): void
+    {
+        if (trim($keyword) === '') {
+            return;
+        }
+        self::createOne([
+            'name' => trim($keyword),
+            'created_at' => date('Y-m-d H:i:s'),
+        ]);
+    }
+}

--- a/src/Controller/Front/ProductSearchController.php
+++ b/src/Controller/Front/ProductSearchController.php
@@ -4,20 +4,20 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.4
+ * @version 2.5
  *
  */
 
 namespace App\Controller\Front;
 
 use App\Event\SearchEvent;
+use App\Event\ProductSearchEvent;
 use HugaShop\Models\Image;
 use HugaShop\Models\Settings;
 use HugaShop\Services\Design;
 use HugaShop\Services\Request;
 use App\Services\PaginationService;
 use HugaShop\Models\Product\Product;
-use HugaShop\Models\ProductSearchKeyword;
 use App\Controller\BaseFrontController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -32,7 +32,7 @@ class ProductSearchController extends BaseFrontController
 
         //$search_query = trim(str_replace('+', ' ',  $search_query)); # use + for whitespace
         $search_query = trim(substr(urldecode($_SERVER['REQUEST_URI']), 3));
-        ProductSearchKeyword::logKeyword($search_query);
+        $this->setEvent(new ProductSearchEvent($search_query));
 
         $noindex = false; # Open indexation
 
@@ -98,7 +98,7 @@ class ProductSearchController extends BaseFrontController
         $query = Request::get('query', 'string');
         if (!empty($query)) {
             $filter['keyword'] = $query;
-            ProductSearchKeyword::logKeyword($query);
+            $this->setEvent(new ProductSearchEvent($query));
             $this->setEvent(new SearchEvent($query));
         }
 

--- a/src/Controller/Front/ProductSearchController.php
+++ b/src/Controller/Front/ProductSearchController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.3
+ * @version 2.4
  *
  */
 
@@ -17,6 +17,7 @@ use HugaShop\Services\Design;
 use HugaShop\Services\Request;
 use App\Services\PaginationService;
 use HugaShop\Models\Product\Product;
+use HugaShop\Models\ProductSearchKeyword;
 use App\Controller\BaseFrontController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -31,6 +32,7 @@ class ProductSearchController extends BaseFrontController
 
         //$search_query = trim(str_replace('+', ' ',  $search_query)); # use + for whitespace
         $search_query = trim(substr(urldecode($_SERVER['REQUEST_URI']), 3));
+        ProductSearchKeyword::logKeyword($search_query);
 
         $noindex = false; # Open indexation
 
@@ -96,7 +98,7 @@ class ProductSearchController extends BaseFrontController
         $query = Request::get('query', 'string');
         if (!empty($query)) {
             $filter['keyword'] = $query;
-
+            ProductSearchKeyword::logKeyword($query);
             $this->setEvent(new SearchEvent($query));
         }
 

--- a/src/Event/ProductSearchEvent.php
+++ b/src/Event/ProductSearchEvent.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andi Huga
+ * @version 1.0
+ */
+
+namespace App\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * This event dispatched when user searches products
+ */
+final class ProductSearchEvent extends Event
+{
+    public function __construct(private string $query) {}
+
+    public function getQuery(): string
+    {
+        return $this->query;
+    }
+}


### PR DESCRIPTION
## Summary
- create `ProductSearchKeyword` model to store search requests
- store keyword in `ProductSearchController`

## Testing
- `php -l hugashop/crm/Models/ProductSearchKeyword.php`
- `php -l src/Controller/Front/ProductSearchController.php`


------
https://chatgpt.com/codex/tasks/task_e_6878798c3cd08326b9000c5697c05cd9