### PR TITLE
Implement old password validation in profile update

### DIFF
--- a/src/Controller/Front/User/UserController.php
+++ b/src/Controller/Front/User/UserController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 3.0
+ * @version 3.1
  *
  */
 
@@ -51,10 +51,12 @@ class UserController extends BaseFrontController
             return false;
         }
 
-        $user_id  = User::authUser('id');
-        $name     = Request::post('name', 'string');
-        $email    = Request::post('email', 'string');
-        $password = Request::post('password', 'string');
+        $user_id         = User::authUser('id');
+        $name            = Request::post('name', 'string');
+        $email           = Request::post('email', 'string');
+        $password        = Request::post('password', 'string');
+        $old_password    = Request::post('old_password', 'string');
+        $confirm_password = Request::post('confirm_password', 'string');
 
         if (empty($name)) {
             Design::append('form_invalid', 'name');
@@ -73,9 +75,14 @@ class UserController extends BaseFrontController
 
         if (!empty($password)) {
 
-            // TODO: Проверять старый пароль
-
-            User::updateUser($user_id, ['password' => $password]);
+            // Проверяем старый пароль
+            if (empty($old_password)
+                || !User::verifyPassword($old_password, User::authUser('password'), $user_id)
+                || $password !== $confirm_password) {
+                Design::append('form_invalid', 'password');
+            } else {
+                User::updateUser($user_id, ['password' => $password]);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- validate old password and confirmation on profile update
- bump UserController version

## Testing
- `php -l src/Controller/Front/User/UserController.php`
- `composer validate --no-check-publish`

------
https://chatgpt.com/codex/tasks/task_e_687b204071608326a2cd42e16aa33e17