### PR TITLE
Fix typos across extensions

### DIFF
--- a/hugashop/crm/Extensions/AdminTemplate/Controller/AdminTemplateController.php
+++ b/hugashop/crm/Extensions/AdminTemplate/Controller/AdminTemplateController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.6
+ * @version 2.7
  *
  */
 
@@ -22,7 +22,7 @@ final class AdminTemplateController extends BaseAdminController
     use BaseExtensionTrait;
 
     /**
-     * Список странниц
+     * Список страниц
      */
     #[Route('/AdminTemplate', name: 'ExtAdminTemplate', priority: 20)]
     public function template()

--- a/hugashop/crm/Extensions/AdminTemplate/templates/template.tpl
+++ b/hugashop/crm/Extensions/AdminTemplate/templates/template.tpl
@@ -82,7 +82,7 @@
                         <div class="col-form-label">125 мб</div>
                     </li>
                     <li>
-                        <div class="col-form-label">Колличество файлов</div>
+                        <div class="col-form-label">Количество файлов</div>
                         <div class="col-form-label">10000 шт</div>
                     </li>
                 </ul>

--- a/hugashop/crm/Extensions/BackToTop/templates/button.tpl
+++ b/hugashop/crm/Extensions/BackToTop/templates/button.tpl
@@ -3,13 +3,13 @@
 <div class="back-to-top"></div>
 <script>
     let mobile_show = parseInt('{$BackToTop->mobile_show}');
-    minClientWidt = 540; // px
+    let minClientWidth = 540; // px
 
     function trackScroll() {
         let scrollY = window.scrollY;
         let clientHeight = document.documentElement.clientHeight;
         let clientWidth = document.documentElement.clientWidth;
-        let show = (mobile_show || clientWidth >= minClientWidt) ? true : false
+        let show = (mobile_show || clientWidth >= minClientWidth) ? true : false
 
         if (scrollY > clientHeight && show) {
             goTopBtn.classList.add('back-to-top-show');

--- a/hugashop/crm/Extensions/BaseExtensionTrait.php
+++ b/hugashop/crm/Extensions/BaseExtensionTrait.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.5
+ * @version 1.6
  *
  */
 
@@ -91,7 +91,7 @@ trait BaseExtensionTrait
 
 
     /**
-     * Fetcj extension template
+     * Fetch extension template
      */
     public function fetchExtResponse(string $template, ?string $block = null)
     {

--- a/hugashop/crm/Extensions/CarouselPromo/Controller/CarouselPromoController.php
+++ b/hugashop/crm/Extensions/CarouselPromo/Controller/CarouselPromoController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.7
+ * @version 1.8
  *
  */
 
@@ -22,7 +22,7 @@ final class CarouselPromoController extends BaseAdminController
     use BaseExtensionTrait;
 
     /**
-     * Список странниц
+     * Список страниц
      */
     #[Route('/CarouselPromo', name: 'ExtCarouselPromo', priority: 20)]
     public function template()

--- a/hugashop/crm/Extensions/CmlExchange/Controller/CmlExchangeController.php
+++ b/hugashop/crm/Extensions/CmlExchange/Controller/CmlExchangeController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.2
+ * @version 1.3
  *
  */
 
@@ -23,7 +23,7 @@ final class CmlExchangeController extends BaseFrontController
     use BaseExtensionTrait;
 
     /**
-     * Список странниц
+     * Список страниц
      */
     #[Route('/CmlExchange/exchange', name: 'ExtCmlExchange', priority: 20)]
     public function exchange(): Response

--- a/hugashop/crm/Extensions/CmlExchange/Services/CmlExchangeService.php
+++ b/hugashop/crm/Extensions/CmlExchange/Services/CmlExchangeService.php
@@ -3,8 +3,8 @@
 /**
  * HugaShop - Sell anything
  * 
- * @author Andi Huga
- * @version 1.6
+ * @author Andri Huga
+ * @version 1.7
  *
  */
 

--- a/hugashop/crm/Extensions/GoogleMerchant/Services/FeedGenerator.php
+++ b/hugashop/crm/Extensions/GoogleMerchant/Services/FeedGenerator.php
@@ -2,8 +2,8 @@
 
 /**
  *
- * @author Andi Huga
- * @version 4.2
+ * @author Andri Huga
+ * @version 4.3
  *
  * Google feed generator
  * Uses Cache

--- a/hugashop/crm/Extensions/InfoBlock/Controller/InfoBlockController.php
+++ b/hugashop/crm/Extensions/InfoBlock/Controller/InfoBlockController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.4
+ * @version 2.5
  *
  */
 
@@ -24,7 +24,7 @@ final class InfoBlockController extends BaseAdminController
     use BaseExtensionTrait;
 
     /**
-     * Список странниц
+     * Список страниц
      */
     #[Route('/InfoBlock/block', name: 'ExtInfoBlockNew', priority: 20)]
     #[Route('/InfoBlock/block/{id}', name: 'ExtInfoBlock', priority: 20)]

--- a/hugashop/crm/Extensions/InfoBlock/Controller/InfoBlockListController.php
+++ b/hugashop/crm/Extensions/InfoBlock/Controller/InfoBlockListController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.3
+ * @version 2.4
  *
  */
 
@@ -24,7 +24,7 @@ final class InfoBlockListController extends BaseAdminController
     use BaseExtensionTrait;
 
     /**
-     * Список странниц
+     * Список страниц
      */
     #[Route('/InfoBlock', name: 'ExtInfoBlockList', priority: 20)]
     public function block()

--- a/hugashop/crm/Extensions/SeoPage/Controller/SeoPageListController.php
+++ b/hugashop/crm/Extensions/SeoPage/Controller/SeoPageListController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.3
+ * @version 2.4
  *
  */
 
@@ -25,7 +25,7 @@ final class SeoPageListController extends BaseAdminController
     use BaseExtensionTrait;
 
     /**
-     * Список странниц
+     * Список страниц
      */
     #[Route('/SeoPage', name: 'ExtSeoPageList', priority: 20)]
     public function index()

--- a/hugashop/crm/Extensions/StorageManager/templates/index.tpl
+++ b/hugashop/crm/Extensions/StorageManager/templates/index.tpl
@@ -37,7 +37,7 @@
                             <div class="col-form-label">{$folder_params->size|byte_convert}</div>
                         </li>
                         <li>
-                            <div class="col-form-label">Колличество файлов</div>
+                            <div class="col-form-label">Количество файлов</div>
                             <div class="col-form-label">{$folder_params->files}</div>
                         </li>
                     </ul>

--- a/hugashop/crm/Extensions/TestScript/Controller/TestScriptController.php
+++ b/hugashop/crm/Extensions/TestScript/Controller/TestScriptController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 3.1
+ * @version 3.2
  *
  */
 
@@ -58,7 +58,7 @@ final class TestScriptController extends BaseAdminController
     use BaseExtensionTrait;
 
     /**
-     * Список странниц
+     * Список страниц
      */
     #[Route('/TestScript', name: 'ExtTestScript', priority: 20)]
     public function test()

--- a/hugashop/crm/Extensions/YandexMerchant/Services/FeedGenerator.php
+++ b/hugashop/crm/Extensions/YandexMerchant/Services/FeedGenerator.php
@@ -2,8 +2,8 @@
 
 /**
  *
- * @author Andi Huga
- * @version 3.4
+ * @author Andri Huga
+ * @version 3.5
  *
  * Use Cache
  * Яндекс фид YXM


### PR DESCRIPTION
## Summary
- fix typos in extension controllers and templates
- unify comment wording
- bump version tags
- tweak BackToTop script variable name

## Testing
- `composer validate --no-check-publish`
- `php -l hugashop/crm/Extensions/AdminTemplate/Controller/AdminTemplateController.php`
- `php -l hugashop/crm/Extensions/BaseExtensionTrait.php`
- `php -l hugashop/crm/Extensions/CarouselPromo/Controller/CarouselPromoController.php`
- `php -l hugashop/crm/Extensions/CmlExchange/Controller/CmlExchangeController.php`
- `php -l hugashop/crm/Extensions/CmlExchange/Services/CmlExchangeService.php`
- `php -l hugashop/crm/Extensions/InfoBlock/Controller/InfoBlockController.php`
- `php -l hugashop/crm/Extensions/InfoBlock/Controller/InfoBlockListController.php`
- `php -l hugashop/crm/Extensions/SeoPage/Controller/SeoPageListController.php`
- `php -l hugashop/crm/Extensions/TestScript/Controller/TestScriptController.php`
- `php -l hugashop/crm/Extensions/GoogleMerchant/Services/FeedGenerator.php`
- `php -l hugashop/crm/Extensions/YandexMerchant/Services/FeedGenerator.php`


------
https://chatgpt.com/codex/tasks/task_e_687c12015db883268b6b421f90eb7fa9