### PR TITLE
Add Feedback extension

### DIFF
--- a/hugashop/crm/Extensions/Feedback/Controller/FeedbackController.php
+++ b/hugashop/crm/Extensions/Feedback/Controller/FeedbackController.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\Feedback\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Request;
+use HugaShop\Models\User\UserNotifier;
+use HugaShop\Models\Content\ContentFeedback;
+use App\Controller\BaseFrontController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class FeedbackController extends BaseFrontController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/feedback', name: 'ExtFeedback', priority: 1)]
+    public function feedback(): Response
+    {
+        if (Request::checkCSRF()) {
+            $feedback = new \stdClass();
+            $feedback->name    = Request::post('name');
+            $feedback->email   = Request::post('email');
+            $feedback->message = Request::post('message');
+
+            Design::assign('name', $feedback->name);
+            Design::assign('email', $feedback->email);
+            Design::assign('message', $feedback->message);
+
+            if (empty($feedback->name)) {
+                Design::append('form_invalid', 'name');
+            } elseif (empty($feedback->email)) {
+                Design::append('form_invalid', 'email');
+            } elseif (empty($feedback->message)) {
+                Design::append('form_invalid', 'text');
+            } else {
+                Design::assign('message_sent', true);
+
+                $feedback->ip = $_SERVER['REMOTE_ADDR'];
+                $feedback_id = ContentFeedback::addFeedback($feedback);
+
+                UserNotifier::sendNotifierToManager('feedbackToAdmin', [
+                    'feedback_id' => $feedback_id,
+                ]);
+            }
+        }
+
+        return $this->fetchExtResponse('feedback.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/Feedback/Controller/FeedbackListController.php
+++ b/hugashop/crm/Extensions/Feedback/Controller/FeedbackListController.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\Feedback\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Request;
+use App\Services\PaginationService;
+use HugaShop\Models\Content\ContentFeedback;
+use App\Controller\BaseAdminController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class FeedbackListController extends BaseAdminController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/Feedback', name: 'ExtFeedbackList', priority: 20)]
+    public function index(): Response
+    {
+        $this->checkAdminAccess('feedback');
+
+        // \u041E\u0431\u0440\u0430\u0431\u043E\u0442\u043A\u0430 \u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0439
+        if (Request::checkCSRF()) {
+            $ids = Request::post('check');
+            if (!empty($ids)) {
+                switch (Request::post('action')) {
+                    case 'delete':
+                        ContentFeedback::deleteOne($ids);
+                        break;
+                }
+            }
+        }
+
+        // \u041E\u0442\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435
+        $filter = PaginationService::initFilter();
+
+        $keyword = Request::get('keyword', 'string');
+        if (!empty($keyword)) {
+            $filter['search'] = $keyword;
+            Design::assign('keyword', $keyword);
+        }
+
+        $feedbacks       = ContentFeedback::getList($filter, order: 'id');
+        $feedbacks_count = ContentFeedback::getCount($filter);
+
+        Design::assign('pagination', PaginationService::getPagination($feedbacks_count, $filter));
+        Design::assign('feedbacks', $feedbacks);
+        Design::assign('feedbacks_count', $feedbacks_count);
+
+        return $this->fetchExtResponse('feedback_list.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/Feedback/Feedback.php
+++ b/hugashop/crm/Extensions/Feedback/Feedback.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\Feedback;
+
+use HugaShop\Extensions\BaseExtension;
+
+final class Feedback extends BaseExtension
+{
+    /**
+     * Get block template
+     */
+    public static function getTemplate(array $params = [])
+    {
+        return self::fetchTemplate('templates/feedback.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/Feedback/settings.yaml
+++ b/hugashop/crm/Extensions/Feedback/settings.yaml
@@ -1,0 +1,9 @@
+name: "Обратная связь"
+description: "Форма обратной связи для пользователей"
+settings_params:
+  - {
+      variable: enabled,
+      name: "Включено",
+      options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }]
+    }
+version: 1.0

--- a/hugashop/crm/Extensions/Feedback/templates/feedback.tpl
+++ b/hugashop/crm/Extensions/Feedback/templates/feedback.tpl
@@ -1,0 +1,58 @@
+{extends 'wrapper/main.tpl'}
+
+{$meta_title = 'Oбратный отзыв'}
+
+{block name=content}
+	<h1>{$page->name}</h1>
+
+	{$page->body}
+
+	<h2>Обратная связь</h2>
+
+	{if $message_sent}
+		{$name}, ваше сообщение отправлено.
+	{else}
+
+		{if $error}
+			<div class="alert alert-danger">
+				{if $error=='captcha'}
+					Подтвердите что вы не робот
+				{/if}
+			</div>
+		{/if}
+
+		<form class="form feedback_form" method="post">
+			{getCSRFInput}
+
+			<div>
+				<label>Имя</label>
+				<input class="form-control {if name|in_array:$form_invalid}is-invalid{/if}" value="{$name}" name="name"
+					maxlength="255" type="text" placeholder="Имя" />
+				<div class="invalid-feedback">Введите имя</div>
+			</div>
+
+			<div>
+				<label>Email</label>
+				<input class="form-control {if email|in_array:$form_invalid}is-invalid{/if}" value="{$email}" name="email"
+					maxlength="255" type="text" placeholder="email" />
+				<div class="invalid-feedback">Введите Email</div>
+			</div>
+
+			<div>
+				<label>Сообщение</label>
+				<textarea class="form-control  {if message|in_array:$form_invalid}is-invalid{/if}" value="{$message}"
+					name="message" placeholder="Сообщение">{$message}</textarea>
+				<div class="invalid-feedback">Введите сообщение</div>
+			</div>
+
+			<div class="col-lg-6">
+				<div class="g-recaptcha" data-sitekey="{$config->recaptcha->public_key}"></div>
+			</div>
+
+			<button class="btn btn-light" type="submit">Отправить</button>
+
+		</form>
+
+		<script src="https://www.google.com/recaptcha/api.js" async defer></script>
+	{/if}
+{/block}

--- a/hugashop/crm/Extensions/Feedback/templates/feedback_list.tpl
+++ b/hugashop/crm/Extensions/Feedback/templates/feedback_list.tpl
@@ -1,0 +1,91 @@
+{extends file='wrapper/main.tpl'}
+{include file='content/parts/menu_part.tpl'}
+
+{* Title *}
+{$meta_title='Обратная связь'}
+
+{block name=content}
+
+	{* Заголовок *}
+	<div class="header_top">
+		{if $feedbacks_count}
+			<h1>{$feedbacks_count} {$feedbacks_count|plural:'сообщение':'сообщений':'сообщения'}</h1>
+		{else}
+			<h1>Нет сообщений</h1>
+		{/if}
+
+		{if $feedbacks || $keyword}
+			<!-- Search -->
+			<form method="get" id="search">
+				<div class="input-group">
+					<input class="search form-control" type="text" name="keyword" value="{$keyword}" />
+					<input class="input-group-text search_button" type="submit" value="" />
+				</div>
+			</form>
+		{/if}
+	</div>
+
+	<div id="main_list">
+
+		{include file='parts/pagination.tpl'}
+
+		{if $feedbacks}
+			<form method="post" class="list_form">
+				{getCSRFInput}
+
+				<div class="list">
+					{foreach $feedbacks as $feedback}
+						<div class="list_row {if !$feedback->visible}visible_off{/if}">
+							<div class="checkbox">
+								<input class="form-check-input" type="checkbox" name="check[]" value="{$feedback->id}" />
+							</div>
+
+							<div class='col comment_text'>
+								{$feedback->message|strip_tags|nl2br|raw}
+							</div>
+
+							<div class="icons">
+								<i class="delete material-icons" data-bs-toggle="tooltip" title="Удалить">cancel</i>
+							</div>
+						</div>
+					{/foreach}
+				</div>
+
+				<div id="action">
+					<span id='check_all' class='dash_link'>Выбрать все</span>
+					<span id=select>
+						<select class="form-select" name="action">
+							<option value="">Выбрать действие</option>
+							<option value="delete">Удалить</option>
+						</select>
+					</span>
+					<button class="btn btn-primary apply" id="apply_action" type="submit">Применить</button>
+				</div>
+			</form>
+
+		{else}
+			Нет сообщений
+		{/if}
+
+		{include file='parts/pagination.tpl'}
+	</div>
+{/block}
+
+
+{block name=body_script append}
+	<script type="module">
+		import { ajax_icon } from '{"js/common.js"|asset}';
+
+		{literal}
+			$(function() {
+
+				// Скрыт/Видим
+				$("i.enable").click(function() {
+					ajax_icon($(this), 'feedback', 'visible', csrf);
+					return false;
+				});
+
+			});
+		{/literal}
+	</script>
+{/block}


### PR DESCRIPTION
## Summary
- add Feedback extension with front and admin controllers
- include Smarty templates and default settings

## Testing
- `php -l hugashop/crm/Extensions/Feedback/Feedback.php`
- `php -l hugashop/crm/Extensions/Feedback/Controller/FeedbackListController.php`
- `php -l hugashop/crm/Extensions/Feedback/Controller/FeedbackController.php`

------
https://chatgpt.com/codex/tasks/task_e_6881aa84f09483269e012a0d0b24199d