### PR TITLE
Implement NotifierInterface for notifier modules

### DIFF
--- a/hugashop/crm/Modules/Notifier/Email/Email.php
+++ b/hugashop/crm/Modules/Notifier/Email/Email.php
@@ -4,11 +4,13 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.6
+ * @version 1.7
  *
  */
 
 namespace HugaShop\Modules\Notifier\Email;
+
+use HugaShop\Modules\Notifier\NotifierInterface;
 
 use HugaShop\Models\Settings;
 use Symfony\Component\Mime\Address;
@@ -17,7 +19,7 @@ use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mime\Email as SEmail;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 
-class Email
+class Email implements NotifierInterface
 {
     /**
      * Send Email

--- a/hugashop/crm/Modules/Notifier/NotifierInterface.php
+++ b/hugashop/crm/Modules/Notifier/NotifierInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Modules\Notifier;
+
+interface NotifierInterface
+{
+    /**
+     * Send notification message
+     *
+     * @param string $message
+     * @param array $params
+     * @return mixed
+     */
+    public static function send(string $message, array $params);
+}

--- a/hugashop/crm/Modules/Notifier/Telegram/Telegram.php
+++ b/hugashop/crm/Modules/Notifier/Telegram/Telegram.php
@@ -4,16 +4,17 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.2
+ * @version 1.3
  *
  */
 
 namespace HugaShop\Modules\Notifier\Telegram;
 
+use HugaShop\Modules\Notifier\NotifierInterface;
 use HugaShop\Services\Config;
 use TelegramBot\NotifyBot;
 
-class Telegram
+class Telegram implements NotifierInterface
 {
     /**
      * Send Message to telegram Chat

--- a/hugashop/crm/Modules/Notifier/Turbosms/Turbosms.php
+++ b/hugashop/crm/Modules/Notifier/Turbosms/Turbosms.php
@@ -4,15 +4,16 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.1
+ * @version 2.2
  *
  */
 
 namespace HugaShop\Modules\Notifier\Turbosms;
 
+use HugaShop\Modules\Notifier\NotifierInterface;
 use Turbosms\TurboSmsSender;
 
-class Turbosms
+class Turbosms implements NotifierInterface
 {
     /**
      * Send Message via Turbosms


### PR DESCRIPTION
## Summary
- add new `NotifierInterface` with `send()` method
- implement the interface in Email, Telegram and Turbosms modules
- bump versions for notifier modules

## Testing
- `php -l hugashop/crm/Modules/Notifier/NotifierInterface.php`
- `php -l hugashop/crm/Modules/Notifier/Email/Email.php`
- `php -l hugashop/crm/Modules/Notifier/Telegram/Telegram.php`
- `php -l hugashop/crm/Modules/Notifier/Turbosms/Turbosms.php`


------
https://chatgpt.com/codex/tasks/task_e_6882aae43ae883268e6cbbef320ea228