### PR TITLE
Implement caching for notifier settings

### DIFF
--- a/hugashop/crm/Models/User/UserNotifier.php
+++ b/hugashop/crm/Models/User/UserNotifier.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 4.2
+ * @version 4.3
  *
  */
 
@@ -12,6 +12,7 @@ namespace HugaShop\Models\User;
 
 use HugaShop\Models\BaseModel;
 use HugaShop\Models\User\UserNotifierType;
+use HugaShop\Services\Cache;
 
 
 
@@ -29,6 +30,8 @@ class UserNotifier extends BaseModel
         'enabled' =>        ['type' => 'int',           'def' => 0],
     ];
 
+    private static array $settings_cache = [];
+
     public function types()
     {
         return $this->hasMany(UserNotifierType::class, 'notifier_id');
@@ -38,6 +41,26 @@ class UserNotifier extends BaseModel
     {
         return $this->belongsToMany(User::class, 'user_notifier_type', 'notifier_id', 'user_id')
             ->withPivot('type');
+    }
+
+    public static function createOne(array|object $values): object
+    {
+        $notifier = parent::createOne($values);
+
+        Cache::cache(self::class)->clear();
+        self::$settings_cache = [];
+
+        return $notifier;
+    }
+
+    public static function updateOne(int $id, array|object $values)
+    {
+        $result = parent::updateOne($id, $values);
+
+        Cache::cache(self::class)->clear();
+        self::$settings_cache = [];
+
+        return $result;
     }
 
 
@@ -58,21 +81,31 @@ class UserNotifier extends BaseModel
      */
     public static function getNotifierSettings(int|string $id): object|bool
     {
-        $query = UserNotifier::query();
+        $key = is_int($id) ? $id : $id;
 
-        if (is_int($id)) {
-            $query->where('id', $id);
+        if (isset(self::$settings_cache[$key])) {
+            return self::$settings_cache[$key];
+        }
+
+        $cache_item = Cache::cache(self::class)->getItem('settings_' . $key);
+        if (!$cache_item->isHit()) {
+            $query = UserNotifier::query();
+
+            if (is_int($id)) {
+                $query->where('id', $id);
+            } else {
+                $query->where('module', $id);
+            }
+
+            $record = $query->value('settings');
+
+            $settings = empty($record) ? false : (object) unserialize($record);
+            Cache::cache(self::class)->save($cache_item->set($settings));
         } else {
-            $query->where('module', $id);
+            $settings = $cache_item->get();
         }
 
-        $record = $query->value('settings');
-
-        if (empty($record)) {
-            return false;
-        }
-
-        return (object) unserialize($record);
+        return self::$settings_cache[$key] = $settings;
     }
 
 


### PR DESCRIPTION
## Summary
- cache notifier settings in `UserNotifier`
- clear cache when notifiers are created or updated

## Testing
- `php -l hugashop/crm/Models/User/UserNotifier.php`

------
https://chatgpt.com/codex/tasks/task_e_6882afc7a98c8326bb169ba1e94e8fd3