### PR TITLE
Add ajax flow for PriceRequest popup

### DIFF
--- a/hugashop/crm/Extensions/PriceRequest/Controller/PriceRequestController.php
+++ b/hugashop/crm/Extensions/PriceRequest/Controller/PriceRequestController.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.1
+ */
+
+namespace HugaShop\Extensions\PriceRequest\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Request;
+use HugaShop\Services\NotifierFactory;
+use App\Controller\BaseFrontController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\HttpFoundation\Response;
+use HugaShop\Extensions\PriceRequest\Models\PriceRequest;
+use HugaShop\Extensions\PriceRequest\Services\NotifyService;
+use HugaShop\Models\Product\Product;
+
+final class PriceRequestController extends BaseFrontController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/PriceRequest/form', name: 'ExtPriceRequestForm', methods: ['GET'], priority: 20)]
+    public function form(): Response
+    {
+        $data = new \stdClass();
+        $data->product_id = Request::getInt('product_id');
+        $data->name       = '';
+        $data->phone      = '';
+        $data->email      = '';
+        $data->link       = '';
+
+        Design::assign('form_data', $data);
+
+        return $this->fetchExtResponse('form.tpl', 'price_request');
+    }
+
+    #[Route('/PriceRequest', name: 'ExtPriceRequest', methods: ['POST'], priority: 20)]
+    public function request(): Response
+    {
+        if (Request::checkCSRF()) {
+            $data = new \stdClass();
+            $data->product_id = Request::postInt('product_id');
+            $data->name       = Request::post('name');
+            $data->phone      = Request::post('phone');
+            $data->email      = Request::post('email');
+            $data->link       = Request::post('link');
+
+            Design::assign('form_data', $data);
+
+            $invalid = [];
+            foreach (['name', 'phone', 'email', 'link'] as $field) {
+                if (empty($data->$field)) {
+                    $invalid[] = $field;
+                }
+            }
+
+            if (empty($invalid)) {
+                $data->ip = $_SERVER['REMOTE_ADDR'];
+                $request  = PriceRequest::createOne($data);
+                $product  = Product::getProduct($request->product_id);
+
+                NotifierFactory::sendToManagers([
+                    NotifyService::class,
+                    'requestToAdmin'
+                ], [
+                    'request' => $request,
+                    'product' => $product
+                ]);
+
+                return $this->fetchExtResponse('sent.tpl', 'price_request');
+            }
+
+            Design::assign('form_invalid', $invalid);
+        }
+
+        return $this->fetchExtResponse('form.tpl', 'price_request');
+    }
+}

--- a/hugashop/crm/Extensions/PriceRequest/Controller/PriceRequestItemController.php
+++ b/hugashop/crm/Extensions/PriceRequest/Controller/PriceRequestItemController.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\PriceRequest\Controller;
+
+use HugaShop\Services\Design;
+use App\Controller\BaseAdminController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\HttpFoundation\Response;
+use HugaShop\Extensions\PriceRequest\Models\PriceRequest;
+
+final class PriceRequestItemController extends BaseAdminController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/PriceRequest/{id}', name: 'ExtPriceRequestItem', priority: 20)]
+    public function item(int $id): Response
+    {
+        $this->checkAdminAccess('extension');
+
+        if (!$request = PriceRequest::getOne($id, ['product', 'product.image'])) {
+            return $this->redirectToRoute('ExtPriceRequestList');
+        }
+
+        Design::assign('request', $request);
+        Design::assign('extension', $this->getExtension());
+        Design::assign('meta_title', 'Запрос #' . $request->id);
+
+        return $this->fetchExtResponse('item.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/PriceRequest/Controller/PriceRequestListController.php
+++ b/hugashop/crm/Extensions/PriceRequest/Controller/PriceRequestListController.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\PriceRequest\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Request;
+use App\Services\PaginationService;
+use App\Controller\BaseAdminController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\HttpFoundation\Response;
+use HugaShop\Extensions\PriceRequest\Models\PriceRequest;
+
+final class PriceRequestListController extends BaseAdminController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/PriceRequest', name: 'ExtPriceRequestList', priority: 20)]
+    public function index(): Response
+    {
+        $this->checkAdminAccess('extension');
+
+        if (Request::checkCSRF()) {
+            $ids = Request::post('check');
+            if (is_array($ids)) {
+                if (Request::post('action') === 'delete') {
+                    PriceRequest::deleteOne($ids);
+                }
+            }
+        }
+
+        $filter = PaginationService::initFilter();
+        $requests = PriceRequest::getList($filter, order: ['created_at', 'desc'], join: ['product']);
+        $requests_count = PriceRequest::getCount($filter);
+
+        Design::assign('requests', $requests);
+        Design::assign('pagination', PaginationService::getPagination($requests_count, $filter));
+        Design::assign('extension', $this->getExtension());
+        Design::assign('meta_title', 'Запросы на скидку');
+
+        return $this->fetchExtResponse('list.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/PriceRequest/Models/PriceRequest.php
+++ b/hugashop/crm/Extensions/PriceRequest/Models/PriceRequest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\PriceRequest\Models;
+
+use HugaShop\Extensions\BaseExtensionModel;
+use HugaShop\Models\Product\Product;
+
+final class PriceRequest extends BaseExtensionModel
+{
+    public $timestamps = true;
+
+    protected static $table_fields = [
+        'id'         => ['type' => 'int', 'extra' => 'AUTO_INCREMENT'],
+        'product_id' => ['type' => 'int', 'req' => true],
+        'name'       => ['type' => 'varchar', 'req' => true],
+        'phone'      => ['type' => 'varchar'],
+        'email'      => ['type' => 'varchar'],
+        'link'       => ['type' => 'varchar'],
+        'ip'         => ['type' => 'varchar', 'length' => 20]
+    ];
+
+    public function product()
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/hugashop/crm/Extensions/PriceRequest/PriceRequest.php
+++ b/hugashop/crm/Extensions/PriceRequest/PriceRequest.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.1
+ */
+
+namespace HugaShop\Extensions\PriceRequest;
+
+use HugaShop\Extensions\BaseExtension;
+
+final class PriceRequest extends BaseExtension
+{
+    /**
+     * Render scripts on front pages
+     */
+    public static function getFrontBodyTemplate()
+    {
+        return self::fetchTemplate('scripts.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/PriceRequest/Services/NotifyService.php
+++ b/hugashop/crm/Extensions/PriceRequest/Services/NotifyService.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\PriceRequest\Services;
+
+use HugaShop\Services\Design;
+use HugaShop\Extensions\BaseExtensionTrait;
+
+final class NotifyService
+{
+    use BaseExtensionTrait;
+
+    /**
+     * Email message to admin
+     */
+    public static function requestToAdmin(string $module_name, array &$message_data)
+    {
+        if (empty($message_data['request']) || empty($message_data['product'])) {
+            return;
+        }
+
+        $template_path = self::getTemplatePath(strtolower($module_name) . '_admin.tpl');
+        if (!file_exists($template_path)) {
+            return;
+        }
+
+        Design::assign('request', $message_data['request']);
+        Design::assign('product', $message_data['product']);
+
+        $message                 = Design::fetch($template_path);
+        $message_data['subject'] = Design::getTemplateVars('subject');
+
+        return $message;
+    }
+}

--- a/hugashop/crm/Extensions/PriceRequest/settings.yaml
+++ b/hugashop/crm/Extensions/PriceRequest/settings.yaml
@@ -1,0 +1,7 @@
+name: "Запрос на скидку"
+description: "Форма запроса более низкой цены"
+notifier:
+  admin:
+    - requestToAdmin: "Запрос на скидку"
+version: 1.0
+

--- a/hugashop/crm/Extensions/PriceRequest/templates/email_pricerequest_admin.tpl
+++ b/hugashop/crm/Extensions/PriceRequest/templates/email_pricerequest_admin.tpl
@@ -1,0 +1,32 @@
+{$subject="Запрос на скидку по товару `$product->name`"}
+
+<h1 style='font-weight:normal;'>Запрос на снижение цены</h1>
+<table cellpadding=6 cellspacing=0 style='border-collapse: collapse;'>
+    <tr>
+        <td style='padding:6px;width:170;background-color:#f0f0f0;border:1px solid #e0e0e0;font-family:arial;'>Товар</td>
+        <td style='padding:6px;width:330;background-color:#ffffff;border:1px solid #e0e0e0;font-family:arial;'>
+            <a href='{$settings->root_url}/product/{$product->url}'>{$product->name}</a>
+        </td>
+    </tr>
+    <tr>
+        <td style='padding:6px;background-color:#f0f0f0;border:1px solid #e0e0e0;font-family:arial;'>ФИО</td>
+        <td style='padding:6px;background-color:#ffffff;border:1px solid #e0e0e0;font-family:arial;'>{$request->name}</td>
+    </tr>
+    <tr>
+        <td style='padding:6px;background-color:#f0f0f0;border:1px solid #e0e0e0;font-family:arial;'>Телефон</td>
+        <td style='padding:6px;background-color:#ffffff;border:1px solid #e0e0e0;font-family:arial;'>{$request->phone}</td>
+    </tr>
+    <tr>
+        <td style='padding:6px;background-color:#f0f0f0;border:1px solid #e0e0e0;font-family:arial;'>Email</td>
+        <td style='padding:6px;background-color:#ffffff;border:1px solid #e0e0e0;font-family:arial;'><a href='mailto:{$request->email}?subject={$settings->domain}'>{$request->email}</a></td>
+    </tr>
+    <tr>
+        <td style='padding:6px;background-color:#f0f0f0;border:1px solid #e0e0e0;font-family:arial;'>Ссылка</td>
+        <td style='padding:6px;background-color:#ffffff;border:1px solid #e0e0e0;font-family:arial;'><a href="{$request->link}">{$request->link}</a></td>
+    </tr>
+    <tr>
+        <td style='padding:6px;background-color:#f0f0f0;border:1px solid #e0e0e0;font-family:arial;'>IP</td>
+        <td style='padding:6px;background-color:#ffffff;border:1px solid #e0e0e0;font-family:arial;'>{$request->ip}</td>
+    </tr>
+</table>
+

--- a/hugashop/crm/Extensions/PriceRequest/templates/form.tpl
+++ b/hugashop/crm/Extensions/PriceRequest/templates/form.tpl
@@ -1,0 +1,30 @@
+<div id="wish_cheaper">
+    <form id="price_request_form" method="post" class="needs-validation">
+        {getCSRFInput}
+        <input type="hidden" name="product_id" value="{$form_data->product_id}">
+        <div class="mb-3">
+            <label class="form-label" for="pr_name">ФИО</label>
+            <input class="form-control {if 'name'|in_array:$form_invalid}is-invalid{/if}" type="text" name="name" id="pr_name" value="{$form_data->name}">
+            <div class="invalid-feedback">Введите имя</div>
+        </div>
+            <div class="mb-3">
+                <label class="form-label" for="pr_phone">Телефон</label>
+                <input class="form-control {if 'phone'|in_array:$form_invalid}is-invalid{/if}" type="text" name="phone" id="pr_phone" value="{$form_data->phone}">
+                <div class="invalid-feedback">Введите телефон</div>
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="pr_email">Email</label>
+                <input class="form-control {if 'email'|in_array:$form_invalid}is-invalid{/if}" type="email" name="email" id="pr_email" value="{$form_data->email}">
+                <div class="invalid-feedback">Введите Email</div>
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="pr_link">Ссылка на дешевле</label>
+                <input class="form-control {if 'link'|in_array:$form_invalid}is-invalid{/if}" type="text" name="link" id="pr_link" value="{$form_data->link}">
+                <div class="invalid-feedback">Укажите ссылку</div>
+            </div>
+        <div class="text-end">
+            <button class="btn btn-light" type="submit">Отправить</button>
+        </div>
+    </form>
+</div>
+

--- a/hugashop/crm/Extensions/PriceRequest/templates/item.tpl
+++ b/hugashop/crm/Extensions/PriceRequest/templates/item.tpl
@@ -1,0 +1,32 @@
+{extends 'wrapper/main.tpl'}
+{include 'extension/parts/menu_part.tpl'}
+
+{block name=content}
+    <div class="header_top">
+        <h1>Запрос #{$request->id}</h1>
+    </div>
+    <div class="row gx-5">
+        <div class="col-lg-6">
+            <ul class="property_block">
+                <li><b>ФИО:</b> {$request->name}</li>
+                <li><b>Телефон:</b> {$request->phone}</li>
+                <li><b>Email:</b> {$request->email}</li>
+                <li><b>Ссылка:</b> <a href="{$request->link}" target="_blank">{$request->link}</a></li>
+                <li><b>IP:</b> {$request->ip}</li>
+                <li><b>Дата:</b> {$request->created_at|date} {$request->created_at|time}</li>
+            </ul>
+        </div>
+        <div class="col-lg-6">
+            {if $request->product}
+                <h2>Товар</h2>
+                <a href="{'ProductAdmin'|link:[id => $request->product->id]}">{$request->product->name}</a>
+                {if $request->product->image}
+                    <div class="mt-2">
+                        <img src="{$request->product->image->filename|resize:200:200}" class="img-thumbnail" alt="" />
+                    </div>
+                {/if}
+            {/if}
+        </div>
+    </div>
+{/block}
+

--- a/hugashop/crm/Extensions/PriceRequest/templates/list.tpl
+++ b/hugashop/crm/Extensions/PriceRequest/templates/list.tpl
@@ -1,0 +1,58 @@
+{extends 'wrapper/main.tpl'}
+{include 'extension/parts/menu_part.tpl'}
+
+{$meta_title='Запросы на скидку'}
+
+{block name=content}
+    <div class="header_top">
+        {if $requests_count}
+            <h1>{$requests_count} {$requests_count|plural:'запрос':'запросов':'запроса'}</h1>
+        {else}
+            <h1>Нет запросов</h1>
+        {/if}
+    </div>
+    <div id="main_list">
+        {if $requests->isNotEmpty()}
+            {include file='parts/pagination.tpl'}
+            <form method="post" class="list_form">
+                {getCSRFInput}
+                <div class="list">
+                    {foreach $requests as $r}
+                        <div class="list_row">
+                            <div class="checkbox">
+                                <input class="form-check-input" type="checkbox" name="check[]" value="{$r->id}" />
+                            </div>
+                            <div class="col">
+                                <a href="{'ExtPriceRequestItem'|link:[id => $r->id]}">{$r->name}</a>
+                                <div class="notice">{$r->phone} {$r->email}</div>
+                                <span class="badge text-bg-round">{$r->created_at|date} {$r->created_at|time}</span>
+                            </div>
+                            <div class="col-4 text-end">
+                                {if $r->product}
+                                    <a href="{'ProductAdmin'|link:[id => $r->product->id]}">{$r->product->name}</a>
+                                {/if}
+                            </div>
+                            <div class="icons">
+                                <i class="delete material-icons" data-bs-toggle="tooltip" title="Удалить">cancel</i>
+                            </div>
+                        </div>
+                    {/foreach}
+                </div>
+                <div id="action">
+                    <span id='check_all' class='dash_link'>Выбрать все</span>
+                    <span id=select>
+                        <select class="form-select" name="action">
+                            <option value="">Выбрать действие</option>
+                            <option value="delete">Удалить</option>
+                        </select>
+                    </span>
+                    <button class="btn btn-primary apply" id="apply_action" type="submit">Применить</button>
+                </div>
+            </form>
+            {include file='parts/pagination.tpl'}
+        {else}
+            Нет запросов
+        {/if}
+    </div>
+{/block}
+

--- a/hugashop/crm/Extensions/PriceRequest/templates/scripts.tpl
+++ b/hugashop/crm/Extensions/PriceRequest/templates/scripts.tpl
@@ -1,0 +1,19 @@
+<script type="module">
+$(function(){
+    $('body').on('click', '.you-price', function(e){
+        e.preventDefault();
+        const productId = $(this).data('product-id');
+        $.get('{'ExtPriceRequestForm'|link}', {product_id: productId}, function(html){
+            $.fancybox.open(html);
+        });
+    });
+
+    $(document).on('submit', '#price_request_form', function(e){
+        e.preventDefault();
+        const form = $(this);
+        $.post('{'ExtPriceRequest'|link}', form.serialize(), function(html){
+            $.fancybox.open(html);
+        });
+    });
+});
+</script>

--- a/hugashop/crm/Extensions/PriceRequest/templates/sent.tpl
+++ b/hugashop/crm/Extensions/PriceRequest/templates/sent.tpl
@@ -1,0 +1,3 @@
+<div id="wish_cheaper_sent">
+    <div class="alert alert-success">Спасибо, ваш запрос отправлен.</div>
+</div>

--- a/templates/asva/product.tpl
+++ b/templates/asva/product.tpl
@@ -96,8 +96,7 @@
 								<span class="price-pdv"></span>
 								<span class="price-amount">{$product->price|price_html|raw}</span>
 							</span>
-							<a href="#" class="you-price" data-fancybox="" data-animation-duration="700" data-touch="false"
-								data-src="#wish_cheaper">Хочу дешевле</a>
+                                                        <a href="#" class="you-price" data-product-id="{$product->id}">Хочу дешевле</a>
 						</div>
 
 						<div class="product-item-purchase">


### PR DESCRIPTION
## Summary
- load price request form via ajax
- submit price requests asynchronously
- show success template when saved
- inject JS script for popup handling
- update product page link

## Testing
- `composer validate --no-check-publish`

------
https://chatgpt.com/codex/tasks/task_e_68887681c7e883268f80db0e9984c2d9