### PR TITLE
Duplicate only original product images when duplicating a product

### DIFF
--- a/hugashop/crm/Models/Image.php
+++ b/hugashop/crm/Models/Image.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 3.9
+ * @version 4.0
  * 
  * Intervention Image
  * @link https://image.intervention.io/v3/getting-started/installation
@@ -83,6 +83,37 @@ class Image extends BaseModel
         ]);
 
         return $image->id;
+    }
+
+
+    /**
+     * Copy original image file and return new unique filename
+     * @param string $filename
+     * @return string|null
+     */
+    public static function copyImage(string $filename): ?string
+    {
+        $src = Config::get('images_originals_dir') . $filename;
+        if (!is_file($src)) {
+            return null;
+        }
+
+        $ext  = pathinfo($filename, PATHINFO_EXTENSION);
+        $base = pathinfo($filename, PATHINFO_FILENAME);
+
+        $unique = $base;
+        $i = 1;
+        while (self::where('filename', $unique . '.' . $ext)->exists()) {
+            $unique = $base . '-' . $i++;
+        }
+
+        $new_filename = $unique . '.' . $ext;
+        $dest = Config::get('images_originals_dir') . $new_filename;
+        if (!@copy($src, $dest)) {
+            return null;
+        }
+
+        return $new_filename;
     }
 
 

--- a/hugashop/crm/Models/Product/Product.php
+++ b/hugashop/crm/Models/Product/Product.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 3.9
+ * @version 4.2
  *
  */
 
@@ -484,7 +484,10 @@ class Product extends BaseModel
         // Дублируем изображения
         $images = Image::getImages($id, 'product');
         foreach ($images as $image) {
-            Image::addImage($new_id, 'product', $image->filename);
+            $new_filename = Image::copyImage($image->filename);
+            if ($new_filename) {
+                Image::addImage($new_id, 'product', $new_filename);
+            }
         }
 
         // Дублируем свойства


### PR DESCRIPTION
## Summary
- copy only original image files when duplicating a product
- add Image::copyImage helper and use it during product duplication

## Testing
- `php -l hugashop/crm/Models/Image.php`
- `php -l hugashop/crm/Models/Product/Product.php`
- `composer test` *(fails: Command "test" is not defined)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer validate` *(publish errors, warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688ffd9e18b88326b910c21a3a4b24b2