### PR TITLE
feat: include selected feature in canonical url

### DIFF
--- a/src/Controller/Front/ProductsController.php
+++ b/src/Controller/Front/ProductsController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 4.0
+ * @version 4.1
  *
  * Этот класс использует шаблон products.tpl
  * Отображение списка товаров, каталог товаров
@@ -60,6 +60,7 @@ class ProductsController extends BaseFrontController
 
         // Parse options from friendly URL /filter/option1/option2
         $selected_features = [];
+        $filter_urls = [];
         if (!empty($filter_path)) {
             $filter_urls = array_filter(explode('/', $filter_path));
             if (!empty($filter_urls)) {
@@ -97,7 +98,11 @@ class ProductsController extends BaseFrontController
         if (empty(Request::gets()) && count($selected_features) === 1) {
             $feature_id = array_key_first($selected_features);
             if (isset($category_features[$feature_id]) && (int) $category_features[$feature_id]->index === 1) {
-                Design::assign('canonical', $this->filterUrl([])); # Set canonical url
+                $option_url = reset($filter_urls);
+                Design::assign('canonical', $this->filterUrl([
+                    'feature_id' => $feature_id,
+                    'option_url' => $option_url,
+                ])); # Set canonical url
                 $noindex = false; # Open indexation
             }
         }


### PR DESCRIPTION
## Summary
- include selected feature option when generating canonical URLs in product listing

## Testing
- `php -l src/Controller/Front/ProductsController.php` *(fails: /usr/bin/php: No such file or directory)*
- `apt-get update` *(fails: gpgv, gpgv2 or gpgv1 required for verification, but neither seems installed)*

------
https://chatgpt.com/codex/tasks/task_e_6893f729939c8326ab4170933d647756