### PR TITLE
Удаление переводов характеристик

### DIFF
--- a/hugashop/crm/Models/Product/ProductFeature.php
+++ b/hugashop/crm/Models/Product/ProductFeature.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.8
+ * @version 2.9
  *
  */
 
@@ -112,6 +112,16 @@ class ProductFeature extends BaseModel
      */
     public static function deleteFeature(int $id)
     {
+        // Идентификаторы вариантов характеристик
+        $option_ids = ProductFeatureOption::where('feature_id', $id)
+            ->pluck('id')
+            ->toArray();
+
+        // Удаляем переводы основной характеристики и её вариантов
+        self::deleteTranslations($id);
+        if (!empty($option_ids)) {
+            ProductFeatureOption::deleteTranslations($option_ids);
+        }
 
         // Удаляем основную характеристику
         self::where('id', $id)->delete();

--- a/hugashop/crm/Models/Traits/TranslationTrait.php
+++ b/hugashop/crm/Models/Traits/TranslationTrait.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.7
+ * @version 1.8
  *
  */
 
@@ -144,6 +144,26 @@ trait TranslationTrait
                 ['entity_id' => $entity_id, 'language_code' => $code],
                 $data
             );
+        });
+    }
+
+
+    /**
+     * Delete translations for provided entity IDs
+     */
+    public static function deleteTranslations(int|array $entity_ids)
+    {
+        $ids = (array) $entity_ids;
+        if (empty($ids)) {
+            return 0;
+        }
+
+        $model = AbstractTranslation::setTableTranslation(static::class);
+
+        return $model->runWithInitTable(function () use ($model, $ids) {
+            return $model->newQuery()
+                ->whereIn('entity_id', $ids)
+                ->delete();
         });
     }
 


### PR DESCRIPTION
## Summary
- remove translations for features and their options
- add generic deleteTranslations method in TranslationTrait

## Testing
- `php -l hugashop/crm/Models/Traits/TranslationTrait.php`
- `php -l hugashop/crm/Models/Product/ProductFeature.php`


------
https://chatgpt.com/codex/tasks/task_e_68941edc7a1c8326a3a985d70ac4ec8f