### PR TITLE
Refactor product feature deletion and translation cleanup

### DIFF
--- a/hugashop/crm/Models/BaseModel.php
+++ b/hugashop/crm/Models/BaseModel.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.6
+ * @version 2.7
  *
  */
 
@@ -244,6 +244,12 @@ abstract class BaseModel extends Model
      */
     public static function deleteOne(array|int $ids)
     {
+        $ids_arr = (array) $ids;
+
+        if (static::isTranslatable()) {
+            static::deleteTranslations($ids_arr);
+        }
+
         return self::query()->whereId($ids)->delete();
     }
 

--- a/hugashop/crm/Models/Product/ProductFeature.php
+++ b/hugashop/crm/Models/Product/ProductFeature.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.9
+ * @version 3.0
  *
  */
 
@@ -117,15 +117,6 @@ class ProductFeature extends BaseModel
             ->pluck('id')
             ->toArray();
 
-        // Удаляем переводы основной характеристики и её вариантов
-        self::deleteTranslations($id);
-        if (!empty($option_ids)) {
-            ProductFeatureOption::deleteTranslations($option_ids);
-        }
-
-        // Удаляем основную характеристику
-        self::where('id', $id)->delete();
-
         // Удаляем опции товара с этой характеристикой
         ProductOption::where('feature_id', $id)->delete();
 
@@ -133,6 +124,11 @@ class ProductFeature extends BaseModel
         ProductCategoryFeature::where('feature_id', $id)->delete();
 
         // Удаляем варианты характеристик
-        ProductFeatureOption::where('feature_id', $id)->delete();
+        if (!empty($option_ids)) {
+            ProductFeatureOption::deleteOne($option_ids);
+        }
+
+        // Удаляем основную характеристику
+        self::deleteOne($id);
     }
 }


### PR DESCRIPTION
## Summary
- use BaseModel::deleteOne for ProductFeature cleanup
- remove translations in BaseModel::deleteOne when model has trans fields

## Testing
- `php -l hugashop/crm/Models/BaseModel.php`
- `php -l hugashop/crm/Models/Product/ProductFeature.php`
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_e_689422480f588326a09f9b683ef17af2