### PR TITLE
feat: add Google oauth registration

### DIFF
--- a/hugashop/crm/Extensions/GoogleAuth/Controller/GoogleAuthController.php
+++ b/hugashop/crm/Extensions/GoogleAuth/Controller/GoogleAuthController.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\GoogleAuth\Controller;
+
+use HugaShop\Models\User\User;
+use HugaShop\Services\Config;
+use HugaShop\Services\Helper;
+use HugaShop\Services\Request;
+use App\Controller\BaseFrontController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class GoogleAuthController extends BaseFrontController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/GoogleAuth', name: 'ExtGoogleAuth', priority: 10)]
+    public function auth(): Response
+    {
+        if (User::isLoggedIn()) {
+            return $this->redirectToRoute('User');
+        }
+
+        $settings = $this->getExtension()->settings;
+        $clientId = $settings->client_id ?? null;
+        $clientSecret = $settings->client_secret ?? null;
+
+        if (empty($clientId) || empty($clientSecret)) {
+            return $this->redirectToRoute('UserRegister');
+        }
+
+        $redirectUri = Config::get('root_url') . '/extension/GoogleAuth';
+        $code = Request::get('code', 'string');
+
+        if (empty($code)) {
+            $params = http_build_query([
+                'response_type' => 'code',
+                'client_id' => $clientId,
+                'redirect_uri' => $redirectUri,
+                'scope' => 'email profile',
+                'prompt' => 'select_account'
+            ]);
+            return $this->redirect('https://accounts.google.com/o/oauth2/v2/auth?' . $params);
+        }
+
+        $params = [
+            'code' => $code,
+            'client_id' => $clientId,
+            'client_secret' => $clientSecret,
+            'redirect_uri' => $redirectUri,
+            'grant_type' => 'authorization_code'
+        ];
+
+        $ch = curl_init('https://oauth2.googleapis.com/token');
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($params));
+        $tokenResponse = curl_exec($ch);
+        curl_close($ch);
+        $tokenInfo = json_decode($tokenResponse, true);
+
+        if (empty($tokenInfo['access_token'])) {
+            return $this->redirectToRoute('UserRegister');
+        }
+
+        $ch = curl_init('https://www.googleapis.com/oauth2/v2/userinfo');
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Authorization: Bearer ' . $tokenInfo['access_token']]);
+        $userInfoResponse = curl_exec($ch);
+        curl_close($ch);
+        $info = json_decode($userInfoResponse, true);
+
+        if (empty($info['email'])) {
+            return $this->redirectToRoute('UserRegister');
+        }
+
+        if (User::checkEmailExists($info['email'])) {
+            $user = User::getUser(['email' => $info['email']]);
+        } else {
+            $user = User::addUser([
+                'name' => $info['name'] ?? $info['email'],
+                'email' => $info['email'],
+                'password' => Helper::makeToken($info['email']),
+                'enabled' => 1
+            ]);
+        }
+
+        Request::setSession('user_id', $user->id);
+        User::setRememberMeCookie($user->id);
+
+        if (!empty(Request::getSession('last_visited_page'))) {
+            return $this->redirect(Request::getSession('last_visited_page'));
+        }
+
+        return $this->redirectToRoute('Main');
+    }
+}

--- a/hugashop/crm/Extensions/GoogleAuth/GoogleAuth.php
+++ b/hugashop/crm/Extensions/GoogleAuth/GoogleAuth.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\GoogleAuth;
+
+use HugaShop\Extensions\BaseExtension;
+
+final class GoogleAuth extends BaseExtension
+{
+    /**
+     * Render Google login button
+     */
+    public static function getTemplate(array $params = [])
+    {
+        if (!self::isEnabled()) {
+            return;
+        }
+        return self::fetchTemplate('button.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/GoogleAuth/settings.yaml
+++ b/hugashop/crm/Extensions/GoogleAuth/settings.yaml
@@ -1,0 +1,7 @@
+name: "Google авторизация"
+description: "Регистрация и авторизация пользователей через Google OAuth"
+settings_params:
+  - { variable: enabled, name: "Включено", options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }] }
+  - { variable: client_id, name: "Client ID" }
+  - { variable: client_secret, name: "Client Secret" }
+version: 1.0

--- a/hugashop/crm/Extensions/GoogleAuth/templates/button.tpl
+++ b/hugashop/crm/Extensions/GoogleAuth/templates/button.tpl
@@ -1,0 +1,3 @@
+<div class="w-100 my-3">
+    <a class="btn btn-outline-danger w-100" href="{'ExtGoogleAuth'|linkLang}">{'Войти через Google'|trans}</a>
+</div>

--- a/src/Controller/Front/User/UserRegisterController.php
+++ b/src/Controller/Front/User/UserRegisterController.php
@@ -4,13 +4,12 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 3.6
+ * @version 3.7
  *
  */
 
 namespace App\Controller\Front\User;
 
-use HugaShop\Services\Config;
 use HugaShop\Services\Design;
 use HugaShop\Services\Helper;
 use HugaShop\Services\Secure;
@@ -86,79 +85,5 @@ class UserRegisterController extends BaseFrontController
         Design::assign('canonical', $this->generateUrl('UserRegister'));
 
         return $this->fetchResponse('user/user_register.tpl');
-    }
-
-    #[Route('/user/register/google', name: 'UserRegisterGoogle', priority: 10)]
-    public function registerGoogle(): Response
-    {
-        if (User::isLoggedIn()) {
-            return $this->redirectToRoute('User');
-        }
-
-        $google = Config::get('google_oauth');
-        $redirectUri = Config::get('root_url') . '/user/register/google';
-        $code = Request::get('code', 'string');
-
-        if (empty($code)) {
-            $params = http_build_query([
-                'response_type' => 'code',
-                'client_id' => $google->client_id,
-                'redirect_uri' => $redirectUri,
-                'scope' => 'email profile',
-                'prompt' => 'select_account'
-            ]);
-            return $this->redirect('https://accounts.google.com/o/oauth2/v2/auth?' . $params);
-        }
-
-        $params = [
-            'code' => $code,
-            'client_id' => $google->client_id,
-            'client_secret' => $google->client_secret,
-            'redirect_uri' => $redirectUri,
-            'grant_type' => 'authorization_code'
-        ];
-
-        $ch = curl_init('https://oauth2.googleapis.com/token');
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_POST, true);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($params));
-        $tokenResponse = curl_exec($ch);
-        curl_close($ch);
-        $tokenInfo = json_decode($tokenResponse, true);
-
-        if (empty($tokenInfo['access_token'])) {
-            return $this->redirectToRoute('UserRegister');
-        }
-
-        $ch = curl_init('https://www.googleapis.com/oauth2/v2/userinfo');
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Authorization: Bearer ' . $tokenInfo['access_token']]);
-        $userInfoResponse = curl_exec($ch);
-        curl_close($ch);
-        $info = json_decode($userInfoResponse, true);
-
-        if (empty($info['email'])) {
-            return $this->redirectToRoute('UserRegister');
-        }
-
-        if (User::checkEmailExists($info['email'])) {
-            $user = User::getUser(['email' => $info['email']]);
-        } else {
-            $user = User::addUser([
-                'name' => $info['name'] ?? $info['email'],
-                'email' => $info['email'],
-                'password' => Helper::makeToken($info['email']),
-                'enabled' => 1
-            ]);
-        }
-
-        Request::setSession('user_id', $user->id);
-        User::setRememberMeCookie($user->id);
-
-        if (!empty(Request::getSession('last_visited_page'))) {
-            return $this->redirect(Request::getSession('last_visited_page'));
-        }
-
-        return $this->redirectToRoute('Main');
     }
 }

--- a/src/Controller/Front/User/UserRegisterController.php
+++ b/src/Controller/Front/User/UserRegisterController.php
@@ -4,12 +4,13 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 3.5
+ * @version 3.6
  *
  */
 
 namespace App\Controller\Front\User;
 
+use HugaShop\Services\Config;
 use HugaShop\Services\Design;
 use HugaShop\Services\Helper;
 use HugaShop\Services\Secure;
@@ -85,5 +86,79 @@ class UserRegisterController extends BaseFrontController
         Design::assign('canonical', $this->generateUrl('UserRegister'));
 
         return $this->fetchResponse('user/user_register.tpl');
+    }
+
+    #[Route('/user/register/google', name: 'UserRegisterGoogle', priority: 10)]
+    public function registerGoogle(): Response
+    {
+        if (User::isLoggedIn()) {
+            return $this->redirectToRoute('User');
+        }
+
+        $google = Config::get('google_oauth');
+        $redirectUri = Config::get('root_url') . '/user/register/google';
+        $code = Request::get('code', 'string');
+
+        if (empty($code)) {
+            $params = http_build_query([
+                'response_type' => 'code',
+                'client_id' => $google->client_id,
+                'redirect_uri' => $redirectUri,
+                'scope' => 'email profile',
+                'prompt' => 'select_account'
+            ]);
+            return $this->redirect('https://accounts.google.com/o/oauth2/v2/auth?' . $params);
+        }
+
+        $params = [
+            'code' => $code,
+            'client_id' => $google->client_id,
+            'client_secret' => $google->client_secret,
+            'redirect_uri' => $redirectUri,
+            'grant_type' => 'authorization_code'
+        ];
+
+        $ch = curl_init('https://oauth2.googleapis.com/token');
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($params));
+        $tokenResponse = curl_exec($ch);
+        curl_close($ch);
+        $tokenInfo = json_decode($tokenResponse, true);
+
+        if (empty($tokenInfo['access_token'])) {
+            return $this->redirectToRoute('UserRegister');
+        }
+
+        $ch = curl_init('https://www.googleapis.com/oauth2/v2/userinfo');
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Authorization: Bearer ' . $tokenInfo['access_token']]);
+        $userInfoResponse = curl_exec($ch);
+        curl_close($ch);
+        $info = json_decode($userInfoResponse, true);
+
+        if (empty($info['email'])) {
+            return $this->redirectToRoute('UserRegister');
+        }
+
+        if (User::checkEmailExists($info['email'])) {
+            $user = User::getUser(['email' => $info['email']]);
+        } else {
+            $user = User::addUser([
+                'name' => $info['name'] ?? $info['email'],
+                'email' => $info['email'],
+                'password' => Helper::makeToken($info['email']),
+                'enabled' => 1
+            ]);
+        }
+
+        Request::setSession('user_id', $user->id);
+        User::setRememberMeCookie($user->id);
+
+        if (!empty(Request::getSession('last_visited_page'))) {
+            return $this->redirect(Request::getSession('last_visited_page'));
+        }
+
+        return $this->redirectToRoute('Main');
     }
 }

--- a/templates/grizlicnc/html/user/user_register.tpl
+++ b/templates/grizlicnc/html/user/user_register.tpl
@@ -45,9 +45,7 @@
                         <div class="w-100">
                                 <button class="btn btn-primary">{'Зарегистрироваться'|trans}</button>
                         </div>
-                        <div class="w-100 my-3">
-                                <a class="btn btn-outline-danger w-100" href="{'UserRegisterGoogle'|linkLang}">{'Войти через Google'|trans}</a>
-                        </div>
+                        {extension name='GoogleAuth'}
                 </form>
         </div>
 

--- a/templates/grizlicnc/html/user/user_register.tpl
+++ b/templates/grizlicnc/html/user/user_register.tpl
@@ -38,15 +38,18 @@
 				<div class="invalid-feedback">{'Введите пароль'|trans}</div>
 			</div>
 
-			<div class="w-100 my-3">
-				<div class="g-recaptcha" data-sitekey="{$config->recaptcha->public_key}"></div>
-			</div>
+                        <div class="w-100 my-3">
+                                <div class="g-recaptcha" data-sitekey="{$config->recaptcha->public_key}"></div>
+                        </div>
 
-			<div class="w-100">
-				<button class="btn btn-primary">{'Зарегистрироваться'|trans}</button>
-			</div>
-		</form>
-	</div>
+                        <div class="w-100">
+                                <button class="btn btn-primary">{'Зарегистрироваться'|trans}</button>
+                        </div>
+                        <div class="w-100 my-3">
+                                <a class="btn btn-outline-danger w-100" href="{'UserRegisterGoogle'|linkLang}">{'Войти через Google'|trans}</a>
+                        </div>
+                </form>
+        </div>
 
 	<script src="https://www.google.com/recaptcha/api.js" async defer></script>
 {/block}


### PR DESCRIPTION
## Summary
- add Google OAuth registration flow and session setup
- show "Войти через Google" button on registration page

## Testing
- `php -l src/Controller/Front/User/UserRegisterController.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_689c0d7403388326947c0ed4d3f917f2