### PR TITLE
feat: paginate user orders

### DIFF
--- a/src/Controller/Front/User/UserOrderListController.php
+++ b/src/Controller/Front/User/UserOrderListController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.2
+ * @version 2.3
  *
  */
 
@@ -13,6 +13,7 @@ namespace App\Controller\Front\User;
 use HugaShop\Models\User\User;
 use HugaShop\Services\Design;
 use HugaShop\Models\Order\Order;
+use App\Services\PaginationService;
 use App\Controller\BaseFrontController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -29,13 +30,19 @@ class UserOrderListController extends BaseFrontController
         }
 
         $user = User::authUser();
-        $orders = Order::getOrders(['user_id' => $user->id], join: [
+
+        $filter = PaginationService::initFilter();
+        $filter['user_id'] = $user->id;
+
+        $orders = Order::getOrders($filter, join: [
             'purchases',
             'purchases.product',
             'purchases.product.image'
         ]);
+        $orders_count = Order::getOrdersCount($filter);
 
         Design::assign('orders', $orders);
+        Design::assign('pagination', PaginationService::getPagination($orders_count, $filter));
         Design::assign('noindex', true); # Запрет индексации страницы
 
         return $this->fetchResponse('user/user_order_list.tpl');

--- a/templates/grizlicnc/html/user/user_order_list.tpl
+++ b/templates/grizlicnc/html/user/user_order_list.tpl
@@ -71,6 +71,7 @@
 					</div>
 				{/foreach}
 
+				{include file='parts/pagination.tpl'}
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary
- paginate user orders in controller
- render pagination widget in user order list template

## Testing
- `php -l src/Controller/Front/User/UserOrderListController.php`
- `composer test` *(fails: Command "test" is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_689d00ecbf5c8326928338a50c1a0138