### PR TITLE
Skip captcha for authenticated comments

### DIFF
--- a/hugashop/crm/Models/Content/ContentComment.php
+++ b/hugashop/crm/Models/Content/ContentComment.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 2.8
+ * @version 3.0
  *
  */
 
@@ -197,8 +197,13 @@ class ContentComment extends BaseModel
      */
     public static function deleteEntityComments($entity_id, $entity_class)
     {
+        $comment_ids = self::where('entity_id', $entity_id)
+            ->where('entity_type', $entity_class)
+            ->pluck('id');
 
-        // TODO удалить фотографии комментария
+        if ($comment_ids->isNotEmpty()) {
+            Image::deleteEntityImages($comment_ids->toArray(), 'comment');
+        }
 
         return self::where('entity_id', $entity_id)
             ->where('entity_type', $entity_class)
@@ -248,7 +253,7 @@ class ContentComment extends BaseModel
             if (!empty($comment->name) and !empty($comment->text) and empty($check_bot_email)) {
 
                 // Chack Captcha
-                if (!Helper::checkCaptcha()) {
+                if (empty(User::authUser('id')) && !Helper::checkCaptcha()) {
                     Design::assign('error', 'captcha');
                 } else {
 

--- a/hugashop/crm/Models/Image.php
+++ b/hugashop/crm/Models/Image.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 4.0
+ * @version 4.1
  * 
  * Intervention Image
  * @link https://image.intervention.io/v3/getting-started/installation
@@ -150,6 +150,19 @@ class Image extends BaseModel
             }
 
             @unlink(Config::get('images_resized_dir') . $filename);
+        }
+    }
+
+    /**
+     * Delete images by entity
+     * @param int|array $entity_id
+     * @param string $entity_type
+     */
+    public static function deleteEntityImages(int|array $entity_id, string $entity_type): void
+    {
+        $images = self::getImages($entity_id, $entity_type);
+        foreach ($images as $image) {
+            self::deleteImage($image->id);
         }
     }
 

--- a/templates/grizlicnc/html/parts/comments.tpl
+++ b/templates/grizlicnc/html/parts/comments.tpl
@@ -99,9 +99,11 @@
                 <div id="comment_images_preview" class="comment_images row g-2 mt-2"></div>
             </div>
 
-            <div class="col-12">
-                <div class="g-recaptcha" data-sitekey="{$config->recaptcha->public_key}"></div>
-            </div>
+            {if $user|empty}
+                <div class="col-12">
+                    <div class="g-recaptcha" data-sitekey="{$config->recaptcha->public_key}"></div>
+                </div>
+            {/if}
 
 
             <div class="col-12">
@@ -113,7 +115,9 @@
 </div>
 
 
-<script src="https://www.google.com/recaptcha/api.js" async defer></script>
+{if $user|empty}
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+{/if}
 <script type="module">
     {literal}
         $('.add_answer').click(function() {


### PR DESCRIPTION
## Summary
- Show reCAPTCHA only to guests in Grizli template
- Bypass captcha validation for authenticated commenters
- Centralize entity image cleanup with `Image::deleteEntityImages` and reuse it for comment removal

## Testing
- `php -l hugashop/crm/Models/Image.php`
- `php -l hugashop/crm/Models/Content/ContentComment.php`
- `composer test` *(fails: Command "test" is not defined)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d068ea5c88326b69fad418aadf261