### PR TITLE
feat: add ProductStockManager extension

### DIFF
--- a/hugashop/crm/Extensions/ProductStockManager/Controller/ProductStockManagerController.php
+++ b/hugashop/crm/Extensions/ProductStockManager/Controller/ProductStockManagerController.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\ProductStockManager\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Request;
+use App\Services\PaginationService;
+use App\Controller\BaseAdminController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Extensions\ProductStockManager\Models\Product;
+
+final class ProductStockManagerController extends BaseAdminController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/ProductStockManager', name: 'ExtProductStockManager', priority: 20)]
+    public function index()
+    {
+        $filter = PaginationService::initFilter();
+
+        if ($keyword = Request::get('keyword')) {
+            $filter['keyword'] = $keyword;
+            Design::assign('keyword', $keyword);
+        }
+
+        $products       = Product::getProducts($filter, join: ['image']);
+        $products_count = Product::countProducts($filter);
+
+        Design::assign('products', $products);
+        Design::assign('products_count', $products_count);
+        Design::assign('pagination', PaginationService::getPagination($products_count, $filter));
+        Design::assign('extension', $this->getExtension());
+
+        return $this->fetchExtResponse('product_list.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/ProductStockManager/Models/Product.php
+++ b/hugashop/crm/Extensions/ProductStockManager/Models/Product.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\ProductStockManager\Models;
+
+use HugaShop\Models\Product\Product as ProductModel;
+
+final class Product extends ProductModel
+{
+    /**
+     * Get Products
+     */
+    public static function getProducts(array $filter = [], array $join = [], bool $count = false)
+    {
+        $model = static::getModel();
+        $query = $model->newQuery();
+
+        if (!empty($filter['keyword'])) {
+            $keywords = explode(' ', trim($filter['keyword']));
+            $query->where(function ($q) use ($keywords) {
+                foreach ($keywords as $kw) {
+                    $q->orWhere('name', 'like', "%$kw%")
+                      ->orWhere('sku', 'like', "%$kw%")
+                      ->orWhere('variant_name', 'like', "%$kw%");
+                }
+            });
+        }
+
+        if ($count) {
+            return $query->count();
+        }
+
+        if (!empty($join)) {
+            $query->with($join);
+        }
+
+        $query->orderByDesc('id');
+
+        if (!empty($filter['limit']) && $filter['limit'] !== 'all') {
+            $limit = max(1, (int)$filter['limit']);
+            $page  = max(1, (int)($filter['page'] ?? 1));
+            $query->limit($limit)->offset(($page - 1) * $limit);
+        }
+
+        return $model->runWithInitTable(fn () => $query->get()->keyBy('id'));
+    }
+
+    /**
+     * Count
+     */
+    public static function countProducts(array $filter = [])
+    {
+        return self::getProducts($filter, count: true);
+    }
+}

--- a/hugashop/crm/Extensions/ProductStockManager/templates/product_list.tpl
+++ b/hugashop/crm/Extensions/ProductStockManager/templates/product_list.tpl
@@ -1,0 +1,65 @@
+{extends 'wrapper/main.tpl'}
+{include 'extension/parts/menu_part.tpl'}
+
+{$meta_title='Товары'}
+
+{block name=content}
+    <div class="two_columns_list">
+        <div class="header_top">
+            <h1>Все товары <span class="sum_total">{$products_count} {$products_count|plural:'товар':'товаров':'товара'}</span></h1>
+
+            <!-- Search -->
+            <form method="get" id="search">
+                <div class="input-group">
+                    <input class="search form-control" type="text" name="keyword" value="{$keyword}"
+                        placeholder="Название, артикул" />
+                    <input class="input-group-text search_button" type="submit" value="" />
+                </div>
+            </form>
+        </div>
+
+        <div id="main_list">
+            {if $products}
+                {include file='parts/pagination.tpl'}
+                <div class="list">
+                    {foreach $products as $product}
+                        <div class="list_row" item_id="{$product->id}">
+                            <div class="image">
+                                <img src="{if $product->image->filename}{$product->image->filename|resize:60:60:c}{else}{'images/cargo.png'|asset}{/if}" />
+                            </div>
+
+                            <div class="col row">
+                                <div class="col">
+                                    <a href="{'ProductAdmin'|link:[id=>$product->id]}?return={$smarty.server.REQUEST_URI}">{$product->name}</a>
+                                    {if $product->variant_name}<span class="small"> - {$product->variant_name}</span>{/if}
+                                </div>
+
+                                <div class="col-12 col-md-4">
+                                    <div class="row">
+                                        <div class="col-6 text-end">
+                                            {if $product->sku}
+                                                <div class="badge text-bg-round copy_field" value="{$product->sku}">{$product->sku}
+                                                    <div class="copy_hover" data-bs-toggle="tooltip" data-bs-original-title="Скопировать">
+                                                        <i class="material-icons">content_copy</i>
+                                                    </div>
+                                                </div>
+                                            {/if}
+                                        </div>
+                                        <div class="col-6 text-end">
+                                            {if $product->stock !== null}
+                                                <span class="badge text-bg-secondary">{$product->stock}</span>
+                                            {/if}
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {/foreach}
+                </div>
+                {include file='parts/pagination.tpl'}
+            {else}
+                <div class="p-3">Нет товаров</div>
+            {/if}
+        </div>
+    </div>
+{/block}


### PR DESCRIPTION
## Summary
- add controller, model, template for ProductStockManager extension to list products without categories

## Testing
- `php -l hugashop/crm/Extensions/ProductStockManager/Controller/ProductStockManagerController.php`
- `php -l hugashop/crm/Extensions/ProductStockManager/Models/Product.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_689d45a033408326b9132464fea8b9b1