### PR TITLE
refactor: use link modifier in templates

### DIFF
--- a/templates/admin/html/order/parts/menu_part.tpl
+++ b/templates/admin/html/order/parts/menu_part.tpl
@@ -1,3 +1,4 @@
+{* @version 0.1 *}
 {block name="tabs"}
 
 	{if 'order'|user_access and $route|in_array:[OrderListAdmin, OrderAdmin, OrderNewAdmin]}
@@ -38,36 +39,36 @@
 	{/if}
 
 
-	{if 'order'|user_access and $route|in_array:[CartListAdmin]}
-		<li class="mini active">
-			<a href="/admin/order/carts">Корзины</a>
-		</li>
-	{/if}
+        {if 'order'|user_access and $route|in_array:[CartListAdmin]}
+                <li class="mini active">
+                        <a href="{'CartListAdmin'|link}">Корзины</a>
+                </li>
+        {/if}
 
 
 	{if $route|in_array:[ManagerProfitAdmin, OrderPaymentListAdmin, OrderPaymentAdmin, OrderPaymentNewAdmin, DeliveryListAdmin, OrderDeliveryAdmin, OrderDeliveryNewAdmin, LabelListAdmin, LabelAdmin, LabelNewAdmin]}
 		{if 'user_manager'|user_access}
 			<li class="mini {if $route|in_array:[ManagerProfitAdmin]}active{/if}">
-				<a href="/admin/order/manager_profit">Доход менеджера</a>
+                                <a href="{'ManagerProfitAdmin'|link}">Доход менеджера</a>
 			</li>
 		{/if}
 
 		{if 'order_payment'|user_access}
 			<li class="mini {if $route|in_array:[OrderPaymentListAdmin, OrderPaymentAdmin, OrderPaymentNewAdmin]}active{/if}">
-				<a href="/admin/order/payments">Оплата</a>
+                                <a href="{'OrderPaymentListAdmin'|link}">Оплата</a>
 			</li>
 		{/if}
 
 		{if 'order_delivery'|user_access}
 			<li class="mini {if $route|in_array:[DeliveryListAdmin, OrderDeliveryAdmin, OrderDeliveryNewAdmin]}active{/if}">
-				<a href="/admin/order/deliveries">Доставка</a>
+                                <a href="{'DeliveryListAdmin'|link}">Доставка</a>
 			</li>
 		{/if}
 
 		{if 'order_label'|user_access}
-			<li class="mini {if $route|in_array:[LabelListAdmin, LabelAdmin, LabelNewAdmin]}active{/if}"><a
-					href="/admin/order/labels">Метки</a></li>
-		{/if}
-	{/if}
+                        <li class="mini {if $route|in_array:[LabelListAdmin, LabelAdmin, LabelNewAdmin]}active{/if}"><a
+                                        href="{'LabelListAdmin'|link}">Метки</a></li>
+                {/if}
+        {/if}
 
 {/block}

--- a/templates/asva/html/parts/header.tpl
+++ b/templates/asva/html/parts/header.tpl
@@ -1,3 +1,4 @@
+{* @version 0.1 *}
 <div class="header-upper-wrapper">
 	<div class="header-upper asva-container">
 
@@ -19,9 +20,9 @@
 			</div>
 		</div>
 
-		<div class="header-logo">
-			<a href="/"><img src="{'images/logo-m.png'|asset}" rel="nofollow"></a>
-		</div>
+                <div class="header-logo">
+                        <a href="{'Main'|linkLang}"><img src="{'images/logo-m.png'|asset}" rel="nofollow"></a>
+                </div>
 
 
 		<div class="header-upper-menu" id="active_header_search">
@@ -92,29 +93,29 @@
 
 <div class="header-wrapper">
 	<div class="header asva-container">
-		<div class="header-logo hidden-phone">
-			<a href="/" title="Интернет магазин шин и дисков АСВА">
-				<img src="{'images/logo.png'|asset}" alt="Интернет магазин шин и дисков АСВА">
-			</a>
-		</div>
-		<div class="header-links">
-			<a href="/shini" title="Шины на авто">
-				<i class="ico ico-tire-car"></i>
-				<span>Шины</span>
-			</a>
-			<a href="/diski" title="Диски на авто">
-				<i class="ico ico-tire-disk"></i>
-				<span>диски</span>
-			</a>
-			<a href="/info/uslugi-shinomontaga" title="Шиномонтаж">
-				<i class="ico ico-tire-fitting"></i>
-				<span>шиномонтаж</span>
-			</a>
-			<a href="/info/tire-storage" title="Хранение">
-				<i class="ico ico-tire-storage"></i>
-				<span>Хранение</span>
-			</a>
-		</div>
+                <div class="header-logo hidden-phone">
+                        <a href="{'Main'|linkLang}" title="Интернет магазин шин и дисков АСВА">
+                                <img src="{'images/logo.png'|asset}" alt="Интернет магазин шин и дисков АСВА">
+                        </a>
+                </div>
+                <div class="header-links">
+                        <a href="{'Products'|linkLang:[url => 'shini']}" title="Шины на авто">
+                                <i class="ico ico-tire-car"></i>
+                                <span>Шины</span>
+                        </a>
+                        <a href="{'Products'|linkLang:[url => 'diski']}" title="Диски на авто">
+                                <i class="ico ico-tire-disk"></i>
+                                <span>диски</span>
+                        </a>
+                        <a href="{'Page'|linkLang:[url => 'uslugi-shinomontaga']}" title="Шиномонтаж">
+                                <i class="ico ico-tire-fitting"></i>
+                                <span>шиномонтаж</span>
+                        </a>
+                        <a href="{'Page'|linkLang:[url => 'tire-storage']}" title="Хранение">
+                                <i class="ico ico-tire-storage"></i>
+                                <span>Хранение</span>
+                        </a>
+                </div>
 
 
 		<!-- Контакты -->


### PR DESCRIPTION
## Summary
- replace hardcoded URLs with `link`/`linkLang` modifiers in admin order menu
- use `linkLang` for navigation links in ASVA header template

## Testing
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_689e88cbb1b883268a0da104edcb082b