### PR TITLE
refactor: use link modifier for finance templates

### DIFF
--- a/templates/admin/html/finance/category_list.tpl
+++ b/templates/admin/html/finance/category_list.tpl
@@ -12,7 +12,7 @@
 			<h1>Нет категорий платежей</h1>
 		{/if}
 
-		<a class="add" href="/admin/finance/category">Добавить категорию платежей</a>
+                <a class="add" href="{'FinanceCategoryNewAdmin'|link}">Добавить категорию платежей</a>
 	</div>
 
 	{if $categories}
@@ -35,7 +35,7 @@
 
 							<div class="col row">
 								<div class="col-12 col-sm-10">
-									<a href="/admin/finance/category/{$c->id}">{$c->name}</a>
+                                                                        <a href="{'FinanceCategoryAdmin'|link:[id => $c->id]}">{$c->name}</a>
 									<div class="notice">{$c->comment|strip_tags|nl2br|raw}</div>
 								</div>
 

--- a/templates/admin/html/finance/parts/menu_part.tpl
+++ b/templates/admin/html/finance/parts/menu_part.tpl
@@ -6,14 +6,14 @@
 			<a href="{'PaymentListAdmin'|link}">Платежи</a>
 		</li>
 
-		<li class="mini right {if $route|in_array:[PurseListAdmin, PurseAdmin, PurseNewAdmin]}active{/if}">
-			<a href="/admin/finance/purses">Кошелки</a>
-		</li>
+                <li class="mini right {if $route|in_array:[PurseListAdmin, PurseAdmin, PurseNewAdmin]}active{/if}">
+                        <a href="{'PurseListAdmin'|link}">Кошелки</a>
+                </li>
 
 		<li
-			class="mini right {if $route|in_array:[FinanceCategoryAdmin, FinanceCategoryListAdmin, FinanceCategoryNewAdmin]}active{/if}">
-			<a href="/admin/finance/categories">Категории платежей</a>
-		</li>
+                        class="mini right {if $route|in_array:[FinanceCategoryAdmin, FinanceCategoryListAdmin, FinanceCategoryNewAdmin]}active{/if}">
+                        <a href="{'FinanceCategoryListAdmin'|link}">Категории платежей</a>
+                </li>
 	{/if}
 
 

--- a/templates/admin/html/finance/payment_list.tpl
+++ b/templates/admin/html/finance/payment_list.tpl
@@ -28,7 +28,7 @@
 
          {foreach $payments_types as $pt}
             <a class="add {$pt->type}" data-bs-toggle="tooltip" title="Создать {$pt->name}"
-               href="/admin/finance/payment?cur_type={$pt->id}">{$pt->name}</a>
+               href="{'PaymentNewAdmin'|link:[cur_type => $pt->id]}">{$pt->name}</a>
          {/foreach}
       </div>
 
@@ -117,7 +117,7 @@
                            <div class="row">
                               <div class="col-5 col-sm-3 text-end {if $p->related_payment_id}transfer{/if}">
                                  <a
-                                    href="/admin/finance/payment/{$p->id}">{$p->amount|price_html:profit:$p->currency_code|raw}</a>
+                                    href="{'PaymentAdmin'|link:[id => $p->id]}">{$p->amount|price_html:profit:$p->currency_code|raw}</a>
 
                                  {if $p->currency_rate!=1 AND !$p->related_payment_id}
                                     <div class="notice">{$p->currency_amount|price_html|raw}</div>
@@ -145,8 +145,8 @@
 
                                        {if !$p->contractor->entity->name|empty}
                                           <div class="notice">
-                                             <a
-                                                href="/admin/{$p->contractor->view_name}/{$p->contractor->entity_id}">{$p->contractor->entity->name}</a>
+                                               <a
+                                                  href="{$p->contractor->view_name|replace:'/':' '|capitalize|replace:' ':''|cat:'Admin'|link:[id => $p->contractor->entity_id]}">{$p->contractor->entity->name}</a>
                                           </div>
                                        {/if}
                                     </div>
@@ -248,7 +248,7 @@
                   options: {
                      label: 'Сумма приходов, ' + php_currency_sign,
                      color: '#76c100',
-                     url: '/admin/ajax/stats/finance',
+                     url: '{'FinanceStatsAdmin'|link}',
                      range: 'year'
                   }
                },
@@ -262,7 +262,7 @@
                   options: {
                      label: 'Сумма расходов, ' + php_currency_sign,
                      color: '#f8a13f',
-                     url: '/admin/ajax/stats/finance',
+                     url: '{'FinanceStatsAdmin'|link}',
                      range: 'year'
                   }
                }

--- a/templates/admin/html/finance/purse_list.tpl
+++ b/templates/admin/html/finance/purse_list.tpl
@@ -21,7 +21,7 @@
 			<h1>Нет кошельков</h1>
 		{/if}
 
-		<a class="add" href="/admin/finance/purse">Добавить кошелек</a>
+                <a class="add" href="{'PurseNewAdmin'|link}">Добавить кошелек</a>
 	</div>
 
 
@@ -46,7 +46,7 @@
 
 							<div class="col row">
 								<div class="col-12 col-sm-8">
-									<a href="/admin/finance/purse/{$p->id}">{$p->name}</a>
+                                                                        <a href="{'PurseAdmin'|link:[id => $p->id]}">{$p->name}</a>
 									<div class="notice">{$p->comment|strip_tags|nl2br|raw}</div>
 								</div>
 


### PR DESCRIPTION
## Summary
- use `link` modifier for finance category list
- refactor payment list links to use `link` modifier
- update purse list and finance menu links to `link` modifier

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ec60c1f7083268f5589fd7df1fbdd