### PR TITLE
Add reCAPTCHA validation to price request form

### DIFF
--- a/hugashop/crm/Extensions/ProductPriceRequest/Controller/PriceRequestController.php
+++ b/hugashop/crm/Extensions/ProductPriceRequest/Controller/PriceRequestController.php
@@ -4,12 +4,13 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.1
+ * @version 1.2
  */
 
 namespace HugaShop\Extensions\ProductPriceRequest\Controller;
 
 use HugaShop\Services\Design;
+use HugaShop\Services\Helper;
 use HugaShop\Services\Secure;
 use HugaShop\Services\Request;
 use HugaShop\Models\Product\Product;
@@ -37,19 +38,23 @@ final class PriceRequestController extends BaseFrontController
 
         if (!empty($request = Secure::getInputAcces(PriceRequest::getFields()))) {
 
-            $request->ip            = $_SERVER['REMOTE_ADDR'];
-            $request->user_agent    = $_SERVER['HTTP_USER_AGENT']; # Browser
-            $request                = PriceRequest::createOne($request);
+            if (Helper::checkCaptcha()) {
+                $request->ip            = $_SERVER['REMOTE_ADDR'];
+                $request->user_agent    = $_SERVER['HTTP_USER_AGENT']; # Browser
+                $request                = PriceRequest::createOne($request);
 
-            NotifierFactory::sendToManagers([
-                NotifyService::class,
-                'priceRequestToAdmin'
-            ], [
-                'request' => $request,
-                'product' => $product
-            ]);
+                NotifierFactory::sendToManagers([
+                    NotifyService::class,
+                    'priceRequestToAdmin'
+                ], [
+                    'request' => $request,
+                    'product' => $product
+                ]);
 
-            return $this->fetchExtResponse('form.tpl', 'request_sent');
+                return $this->fetchExtResponse('form.tpl', 'request_sent');
+            } else {
+                Design::assign('error', 'captcha');
+            }
         }
 
         Design::assign('product', $product);

--- a/hugashop/crm/Extensions/ProductPriceRequest/templates/form.tpl
+++ b/hugashop/crm/Extensions/ProductPriceRequest/templates/form.tpl
@@ -18,6 +18,14 @@
                         цену.</p>
                 </div>
 
+                {if $error}
+                    <div class="alert alert-danger">
+                        {if $error=='captcha'}
+                            Подтвердите что вы не робот
+                        {/if}
+                    </div>
+                {/if}
+
                 <form method="post" action="{'ExtPriceRequestForm'|link}" class="needs-validation">
                     <input type="hidden" name="product_id" value="{$product->id}">
                     {getCSRFInput}
@@ -42,10 +50,14 @@
                         <label class="form-label" for="pr_comment">Ссылка на дешевле или причина запроса</label>
                         <input class="form-control" type="text" name="comment" id="pr_comment" value="{$request->comment}">
                     </div>
+                    <div class="mb-3">
+                        <div class="g-recaptcha" data-sitekey="{$config->recaptcha->public_key}"></div>
+                    </div>
                     <div class="text-end">
                         <button class="btn btn-primary" type="submit">Отправить</button>
                     </div>
                 </form>
+                <script src="https://www.google.com/recaptcha/api.js" async defer></script>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add server-side Google reCAPTCHA verification for price request submissions
- render reCAPTCHA widget and captcha error message in price request form template

## Testing
- `php -l hugashop/crm/Extensions/ProductPriceRequest/Controller/PriceRequestController.php`


------
https://chatgpt.com/codex/tasks/task_e_68a10be6e4e48326b354631bfe869d0c