### PR TITLE
refactor: use link modifier in admin product templates

### DIFF
--- a/templates/admin/html/product/brand_list.tpl
+++ b/templates/admin/html/product/brand_list.tpl
@@ -6,10 +6,10 @@
 {block name=content}
 
 	{* Заголовок *}
-	<div class=header_top>
-		<h1>{$meta_title}</h1>
-		<a class="add" href="/admin/product/brand">Добавить бренд</a>
-	</div>
+<div class=header_top>
+<h1>{$meta_title}</h1>
+<a class="add" href="{'BrandNewAdmin'|link}">Добавить бренд</a>
+</div>
 
 
 	<div id="main_list">
@@ -28,9 +28,9 @@
 								</div>
 							{/if}
 
-							<div class="col">
-								<a href="/admin/product/brand/{$brand->id}">{$brand->name}</a>
-							</div>
+<div class="col">
+<a href="{'BrandAdmin'|link:[id => $brand->id]}">{$brand->name}</a>
+</div>
 
 							{if $brand->image}
 								<div class="brand_image">

--- a/templates/admin/html/product/category.tpl
+++ b/templates/admin/html/product/category.tpl
@@ -68,11 +68,11 @@
 							{category_select cats=$categories}
 						</select>
 
-						{if $category->id}
-							<a class="out_link mt-3" href="/admin/products?category_id={$category->id}">
-								Перейти к товарам категории в админке
-							</a>
-						{/if}
+{if $category->id}
+<a class="out_link mt-3" href="{'ProductListAdmin'|link:[category_id => $category->id]}">
+Перейти к товарам категории в админке
+</a>
+{/if}
 					</div>
 				</div>
 

--- a/templates/admin/html/product/category_list.tpl
+++ b/templates/admin/html/product/category_list.tpl
@@ -6,11 +6,11 @@
 {block name=content}
 
 	{* Заголовок *}
-	<div class="header_top">
-		<h1>{$meta_title}</h1>
-		<a class="add" href="/admin/product/category">Добавить
-			категорию</a>
-	</div>
+<div class="header_top">
+<h1>{$meta_title}</h1>
+<a class="add" href="{'CategoryNewAdmin'|link}">Добавить
+категорию</a>
+</div>
 
 
 	<div id="main_list">
@@ -37,7 +37,7 @@
 
 										<div class="col row">
 											<div class="col-12 col-md-10 {if $category->level == 1}fw-semibold{/if}">
-												<a href="/admin/product/category/{$category->id}">{$category->name}</a>
+<a href="{'CategoryAdmin'|link:[id => $category->id]}">{$category->name}</a>
 											</div>
 											<div class="col-12 col-md-2 text-end">
 												{if $category->main}
@@ -47,8 +47,8 @@
 										</div>
 
 										<div class="icons">
-											<a class="material-icons launch" title="Предпросмотр в новом окне"
-												href="{$config->root_url}/{$category->url}"></a>
+<a class="material-icons launch" title="Предпросмотр в новом окне"
+href="{'Products'|linkLang:[url => $category->url]}"></a>
 											<i class="enable material-icons visibility" title="Активна"></i>
 											<i class="delete material-icons" title="Удалить">cancel</i>
 										</div>

--- a/templates/admin/html/product/feature_list.tpl
+++ b/templates/admin/html/product/feature_list.tpl
@@ -8,10 +8,10 @@
 	<div class="two_columns_list">
 
 		<!-- Заголовок -->
-		<div class="header_top">
-			<h1>{$meta_title}</h1>
-			<a class="add" href="/admin/product/feature">Добавить свойство</a>
-		</div>
+<div class="header_top">
+<h1>{$meta_title}</h1>
+<a class="add" href="{'FeatureNewAdmin'|link}">Добавить свойство</a>
+</div>
 
 		<!-- Меню -->
 		<div class="navbar-expand-lg" id="right_menu">
@@ -67,9 +67,9 @@
 									<input class="form-check-input" type="checkbox" name="check[]" value="{$feature->id}" />
 								</div>
 
-								<div class="col">
-									<a href="/admin/product/feature/{$feature->id}">{$feature->name}</a>
-								</div>
+<div class="col">
+<a href="{'FeatureAdmin'|link:[id => $feature->id]}">{$feature->name}</a>
+</div>
 
 								<div class="col-2">
 									{if $feature->index}

--- a/templates/admin/html/product/parts/menu_part.tpl
+++ b/templates/admin/html/product/parts/menu_part.tpl
@@ -1,29 +1,29 @@
 {block name=tabs}
 
-	{if 'product_view'|user_access}
-		<li
-			class="mini {if $route|in_array:[ProductListAdmin, ProductAdmin, ProductPriceAdmin, ImportProductPAdmin]}active{/if}">
-			<a href="/admin/products">Товары</a>
-		</li>
-	{/if}
+{if 'product_view'|user_access}
+<li
+class="mini {if $route|in_array:[ProductListAdmin, ProductAdmin, ProductPriceAdmin, ImportProductPAdmin]}active{/if}">
+<a href="{'ProductListAdmin'|link}">Товары</a>
+</li>
+{/if}
 
 	<!-- Правая часть -->
 	{if 'product_category'|user_access}
-		<li class="mini right {if $route|in_array:[CategoryListAdmin, CategoryAdmin, CategoryNewAdmin]}active{/if}">
-			<a href="/admin/product/categories">Категории</a>
-		</li>
-	{/if}
+<li class="mini right {if $route|in_array:[CategoryListAdmin, CategoryAdmin, CategoryNewAdmin]}active{/if}">
+<a href="{'CategoryListAdmin'|link}">Категории</a>
+</li>
+{/if}
 
 	{if 'product_feature'|user_access}
-		<li class="mini right {if $route|in_array:[FeatureListAdmin, FeatureAdmin, FeatureNewAdmin]}active{/if}">
-			<a href="/admin/product/features">Характеристики</a>
-		</li>
-	{/if}
+<li class="mini right {if $route|in_array:[FeatureListAdmin, FeatureAdmin, FeatureNewAdmin]}active{/if}">
+<a href="{'FeatureListAdmin'|link}">Характеристики</a>
+</li>
+{/if}
 
 	{if 'product_brand'|user_access}
-		<li class="mini right {if $route|in_array:[BrandListAdmin, BrandAdmin, BrandNewAdmin]}active{/if}">
-			<a href="/admin/product/brands">Бренды</a>
-		</li>
-	{/if}
+<li class="mini right {if $route|in_array:[BrandListAdmin, BrandAdmin, BrandNewAdmin]}active{/if}">
+<a href="{'BrandListAdmin'|link}">Бренды</a>
+</li>
+{/if}
 
 {/block}

--- a/templates/admin/html/product/parts/submenu_part.tpl
+++ b/templates/admin/html/product/parts/submenu_part.tpl
@@ -3,28 +3,28 @@
 	<ul id="submenu" class="submenu">
 
 		{if 'product_content'|user_access}
-			<li class="{if $route|in_array:[ProductAdmin, ProductNewAdmin]}active{/if}">
-				<a href="/admin/product/{$product->id}">Контент</a>
-			</li>
-		{/if}
+<li class="{if $route|in_array:[ProductAdmin, ProductNewAdmin]}active{/if}">
+<a href="{'ProductAdmin'|link:[id => $product->id]}">Контент</a>
+</li>
+{/if}
 
                 {if 'product_price'|user_access and $product->id}
-                        <li class="{if $route == 'ProductPriceAdmin'}active{/if}">
-                                <a href="/admin/product/{$product->id}/price">Цены</a>
-                        </li>
-                {/if}
+<li class="{if $route == 'ProductPriceAdmin'}active{/if}">
+<a href="{'ProductPriceAdmin'|link:[id => $product->id]}">Цены</a>
+</li>
+{/if}
 
                 {if 'order'|user_access and $product->id}
-                        <li class="{if $route == 'ProductOrdersAdmin'}active{/if}">
-                                <a href="/admin/product/{$product->id}/orders">Заказы</a>
-                        </li>
-                {/if}
+<li class="{if $route == 'ProductOrdersAdmin'}active{/if}">
+<a href="{'ProductOrdersAdmin'|link:[id => $product->id]}">Заказы</a>
+</li>
+{/if}
 
                 {if 'warehouse'|user_access and $product->id}
-                        <li class="{if $route == 'ProductMoveAdmin'}active{/if}">
-                                <a href="/admin/product/{$product->id}/move">Поставки</a>
-                        </li>
-                {/if}
+<li class="{if $route == 'ProductMoveAdmin'}active{/if}">
+<a href="{'ProductMoveAdmin'|link:[id => $product->id]}">Поставки</a>
+</li>
+{/if}
 
 		{if $smarty.get.return}
 			<li class="back">

--- a/templates/admin/html/product/product.tpl
+++ b/templates/admin/html/product/product.tpl
@@ -23,14 +23,14 @@
 				<div class="over_name">
 					<div class="checkbox_line"></div>
 					<div class="link_line">
-						{if $product->category_id}
-							<a class="out_link" href="/admin/products?category_id={$product->category_id}">Перейти к товарам
-								категории в админке</a>
-						{/if}
-						{if $product->id}
-							<a class="out_link" target="_self" href="{'Product'|linkLang:[url => $product->url]}">Открыть товар
-								на сайте</a>
-						{/if}
+{if $product->category_id}
+<a class="out_link" href="{'ProductListAdmin'|link:[category_id => $product->category_id]}">Перейти к товарам
+категории в админке</a>
+{/if}
+{if $product->id}
+<a class="out_link" target="_self" href="{'Product'|linkLang:[url => $product->url]}">Открыть товар
+на сайте</a>
+{/if}
 					</div>
 				</div>
 				<div class="name_row">

--- a/templates/admin/html/product/product_import.tpl
+++ b/templates/admin/html/product/product_import.tpl
@@ -127,7 +127,7 @@
 					</div>
 				</span>
 
-				<a target="_blank" href="/admin/product/{$item->product->id}/price">{$item->product->name}</a>
+<a target="_blank" href="{'ProductPriceAdmin'|link:[id => $item->product->id]}">{$item->product->name}</a>
 				{if $item->variant->name}
 					- {$item->variant->name} -
 				{/if}

--- a/templates/admin/html/product/product_list.tpl
+++ b/templates/admin/html/product/product_list.tpl
@@ -33,23 +33,23 @@
 				<h1>Нет товаров</h1>
 			{/if}
 
-			{if 'product_content'|user_access}
-				<a class="add" href="/admin/product">Добавить товар</a>
-			{/if}
+{if 'product_content'|user_access}
+<a class="add" href="{'ProductNewAdmin'|link}">Добавить товар</a>
+{/if}
 
 			<div class="btns_wrap">
-				{if 'product_import'|user_access AND $products_count > 0}
-					<a class="export_btn" href="/admin/products/export?{$smarty.server.QUERY_STRING}">
-						<img src="{'images/export_excel.png'|asset}" name="export" data-bs-toggle="tooltip"
-							title="Экспортировать товары" />
-					</a>
+{if 'product_import'|user_access AND $products_count > 0}
+<a class="export_btn" href="{'ProductExport'|link}?{$smarty.server.QUERY_STRING}">
+<img src="{'images/export_excel.png'|asset}" name="export" data-bs-toggle="tooltip"
+title="Экспортировать товары" />
+</a>
 
-					<a class="export_btn" href="/admin/products/import">
-						<img src="{'images/import_excel.png'|asset}" name="import" data-bs-toggle="tooltip"
-							title="Импортировать товары" />
-					</a>
-				{/if}
-			</div>
+<a class="export_btn" href="{'ProductsImportPAdmin'|link}">
+<img src="{'images/import_excel.png'|asset}" name="import" data-bs-toggle="tooltip"
+title="Импортировать товары" />
+</a>
+{/if}
+</div>
 
 			<!-- Search -->
 			<form method="get" id="search">
@@ -110,9 +110,9 @@
 
 		<!--  Основная форма -->
 		<div id="main_list">
-			{if $category->id}
-				<a class="out_link" target="_self" href="{$config->root_url}/{$category->url}">Открыть категорию на сайте</a>
-			{/if}
+{if $category->id}
+<a class="out_link" target="_self" href="{'Products'|linkLang:[url => $category->url]}">Открыть категорию на сайте</a>
+{/if}
 
 			{if $products}
 				{if 'stats'|user_access AND $category->id}
@@ -183,9 +183,9 @@
 												<i class="duplicate material-icons library_add" data-bs-toggle="tooltip"
 													title="Дублировать"></i>
 											{/if}
-											<a class="material-icons launch" data-bs-toggle="tooltip"
-												title="Предпросмотр в новом окне" href="{$config->root_url}/product/{$product->id}"
-												target="_blank"></a>
+<a class="material-icons launch" data-bs-toggle="tooltip"
+title="Предпросмотр в новом окне" href="{'Product'|linkLang:[url => $product->url]}"
+target="_blank"></a>
 										</div>
 									</div>
 
@@ -207,7 +207,7 @@
 													<a data-bs-toggle="tooltip" data-bs-html="true" {if $product->cost_price > 0}
 															title="Оптовая цена &mdash; {$product->cost_price|number} {$currency->sign}</br>Доход &mdash; {$product->profit_price|number} {$currency->sign}</br> Старая цена  &mdash; {$product->old_price|number} {$currency->sign}"
 														{/if}
-														href="/admin/product/{$product->id}/price?return={$smarty.server.REQUEST_URI}">{$product->price|price_html|raw}</a>
+href="{'ProductPriceAdmin'|link:[id => $product->id]}?return={$smarty.server.REQUEST_URI}">{$product->price|price_html|raw}</a>
 												{else}
 													{$product->price|price_html|raw}
 												{/if}

--- a/templates/admin/html/product/product_price.tpl
+++ b/templates/admin/html/product/product_price.tpl
@@ -48,15 +48,15 @@
 						</div>
 					</div>
 					<div class="link_line">
-						{if $product->category_id}
-							<a class='out_link' href="/admin/products?category_id={$product->category_id}">Перейти к товарам
-								категории в админке</a>
-						{/if}
-						{if $product->id}
-							<a class="out_link" target="_self" href="{$settings->site_url}/product/{$product->id}">Открыть товар
-								на сайте</a>
-						{/if}
-					</div>
+{if $product->category_id}
+<a class='out_link' href="{'ProductListAdmin'|link:[category_id => $product->category_id]}">Перейти к товарам
+категории в админке</a>
+{/if}
+{if $product->id}
+<a class="out_link" target="_self" href="{'Product'|linkLang:[url => $product->url]}">Открыть товар
+на сайте</a>
+{/if}
+</div>
 				</div>
 				<div class="name_row">
 					<input class="form-control form-control-lg" name="name" type="text" value="{$product->name}"


### PR DESCRIPTION
## Summary
- replace hardcoded admin product menu links with `link` modifier
- switch product list actions and previews to route-based links
- update product price and import templates to use dynamic links

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `php -l templates/admin/html/product/product_list.tpl`


------
https://chatgpt.com/codex/tasks/task_e_68a14e6321c08326809d15074dea83cc