### PR TITLE
Refactor templates to use link modifier for internal URLs

### DIFF
--- a/templates/asva/html/parts/footer.tpl
+++ b/templates/asva/html/parts/footer.tpl
@@ -4,10 +4,10 @@
             <div>
                 <div class="f-title">Информация</div>
                 <a href="{'PostList'|linkLang}">Новости магазина</a>
-                <a href="/article/">Полезные статьи</a>
-                <a href="/information/reference_data/">Маркировка шин</a>
-                <a href="/spec_orders/">Акции и скидки</a>
-                <a href="/information/credit/">Шины в кредит</a>
+                <a href="{'Page'|linkLang:[url => 'article']}">Полезные статьи</a>
+                <a href="{'Page'|linkLang:[url => 'information/reference_data']}">Маркировка шин</a>
+                <a href="{'Page'|linkLang:[url => 'spec_orders']}">Акции и скидки</a>
+                <a href="{'Page'|linkLang:[url => 'information/credit']}">Шины в кредит</a>
             </div>
             <div>
                 <div class="f-title">Шины</div>
@@ -25,14 +25,14 @@
             </div>
             <div>
                 <div class="f-title">Услуги и сервис</div>
-                <a href="/services/tire_repair/">Ремонт шин</a>
-                <a href="/services/disk_repair/">Ремонт дисков</a>
-                <a href="/services/tire_storage/">Сезонное хранение шин</a>
-                <a href="/services/disk_painting/">Покраска дисков</a>
-                <a href="/services/car_air_conditioning_service/">Обслуживание автокондиционеров</a>
-                <a href="/services/oil_and_filters_replacement/">Замена масла и фильтров</a>
-                <a href="/services/brake_shoes_replacement/">Замена тормозных колодок</a>
-                <a href="/services/auto_parts_selections/">Подбор запчастей по VIN коду</a>
+                <a href="{'Page'|linkLang:[url => 'services/tire_repair']}">Ремонт шин</a>
+                <a href="{'Page'|linkLang:[url => 'services/disk_repair']}">Ремонт дисков</a>
+                <a href="{'Page'|linkLang:[url => 'services/tire_storage']}">Сезонное хранение шин</a>
+                <a href="{'Page'|linkLang:[url => 'services/disk_painting']}">Покраска дисков</a>
+                <a href="{'Page'|linkLang:[url => 'services/car_air_conditioning_service']}">Обслуживание автокондиционеров</a>
+                <a href="{'Page'|linkLang:[url => 'services/oil_and_filters_replacement']}">Замена масла и фильтров</a>
+                <a href="{'Page'|linkLang:[url => 'services/brake_shoes_replacement']}">Замена тормозных колодок</a>
+                <a href="{'Page'|linkLang:[url => 'services/auto_parts_selections']}">Подбор запчастей по VIN коду</a>
             </div>
 
 
@@ -62,7 +62,7 @@
                     <?= date('Y');?> ACBA. Всі права захищені
                 </p>
                 <span>|</span>
-                <a href="/sitemap/">Карта сайта</a>
+                <a href="{'Page'|linkLang:[url => 'sitemap']}">Карта сайта</a>
             </div>
         </div>
     </div>

--- a/templates/asva/html/product.tpl
+++ b/templates/asva/html/product.tpl
@@ -183,8 +183,8 @@
 				{/if}
 
 				<p>
-					<span>Детальное описание и таблица типоразмеров на странице модели <a class="desc-more"
-							href="/catalog/142270/254897/">шины {$product->name}</a></span>
+                                <span>Детальное описание и таблица типоразмеров на странице модели <a class="desc-more"
+                                                        href="{'Products'|linkLang:[url => 'catalog/142270/254897']}">шины {$product->name}</a></span>
 				</p>
 			</div>
 		</div>
@@ -205,7 +205,7 @@
 				{foreach $product_analogs as $aproduct}
 					<div class="analogs-by-type-item">
 						<div class="art">{$aproduct->name}</div>
-						<a href="/catalog/59988/69032/69029/" class="name">
+                                                <a href="{'Products'|linkLang:[url => 'catalog/59988/69032/69029']}" class="name">
 							385/65 R 22.5 Satoya ST-082 160K прич </a>
 
 						<div class="spec">
@@ -216,7 +216,7 @@
 						<div class="price">9979 </div>
 
 						<div class="buy">
-							<a class="button" href="/catalog/59988/69032/69029/">Купить</a>
+                                                        <a class="button" href="{'Products'|linkLang:[url => 'catalog/59988/69032/69029']}">Купить</a>
 						</div>
 					</div>
 				{/foreach}
@@ -261,19 +261,19 @@
 				<div class="selection-buyer-info delivery-srvices">
 					<div class="delivery-srvice pickup">
 						<h3>Самовывоз в Киеве </h3>
-						<p>- <a href="/detail/contacts.php" rel="nofollow">из офиса</a> <span>(бесплатно)</span></p>
-						<p>- <a href="/uslugi-shinomontaga/" ref="nofollow">установка шин на шиносервисе</a></p>
+                                                  <p>- <a href="{'Page'|linkLang:[url => 'contact']}" rel="nofollow">из офиса</a> <span>(бесплатно)</span></p>
+                                                  <p>- <a href="{'Page'|linkLang:[url => 'uslugi-shinomontaga']}" ref="nofollow">установка шин на шиносервисе</a></p>
 					</div>
 					<div class="delivery-srvice city">
 						<h3>Доставка по Киеву </h3>
-						<p><a href="/information/delivery/" rel="nofollow">Стоимость услуги 500 грн</a></p>
+                                                  <p><a href="{'Page'|linkLang:[url => 'information/delivery']}" rel="nofollow">Стоимость услуги 500 грн</a></p>
 					</div>
 					<div class="delivery-srvice country">
 						<h3>Доставка по Украине </h3>
 						<p><span>по тарифам перевозчиков</span></p>
 					</div>
 					<div class="delivery-srvice transport">
-						<p><a href="/information/delivery/" rel="nofollow">Условия доставки</a></p>
+                                                  <p><a href="{'Page'|linkLang:[url => 'information/delivery']}" rel="nofollow">Условия доставки</a></p>
 						<img src="{'images/ico-np.jpg'|asset}" alt="НоваяПочта">
 						<img src="{'images/ico-cat.jpg'|asset}" alt="CAT">
 						<img src="{'images/ico-delivery.jpg'|asset}" alt="DELIVERY">
@@ -288,11 +288,11 @@
 				</div>
 				<div class="selection-buyer-info warranty-info">
 					<div class="warranty-srvice from-store">
-						<a href="/information/garanty/" rel="nofollow">Гарантия от магазина</a>
+                                                  <a href="{'Page'|linkLang:[url => 'information/garanty']}" rel="nofollow">Гарантия от магазина</a>
 					</div>
 
 					<div class="warranty-srvice from-store">
-						<a href="/information/garanty/" rel="nofollow"> Вы можете вернуть товар (14 дней)</a>
+                                                  <a href="{'Page'|linkLang:[url => 'information/garanty']}" rel="nofollow"> Вы можете вернуть товар (14 дней)</a>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- replace hardcoded product links with the `linkLang` modifier
- switch footer info/service links to the `linkLang` modifier

## Testing
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68a151881b9083268ef32920fa10738b