### PR TITLE
Use link modifiers for template links

### DIFF
--- a/templates/admin/html/content/comment.tpl
+++ b/templates/admin/html/content/comment.tpl
@@ -21,10 +21,10 @@
             <div class="col-12">
                 <div class="over_name">
                     {if $comment->type == 'product'}
-                        <a class="out_link" target="_bkank" href="{$config->root_url}/product/{$comment->entity->id}">Открыть
+                        <a class="out_link" target="_bkank" href="{'ProductId'|linkLang:[id => $comment->entity->id]}">Открыть
                             товар на сайте</a>
                     {elseif $comment->type == 'blog'}
-                        <a class="out_link" target="_bkank" href="{$config->root_url}/blog/{$comment->entity->url}">Открыть
+                        <a class="out_link" target="_bkank" href="{'Post'|linkLang:[url => $comment->entity->url]}">Открыть
                             статью на
                             сайте</a>
                     {/if}
@@ -47,7 +47,7 @@
                     {if !empty($comment->user)}
                         <li>
                             <div class="col-form-label">Пользователь</div>
-                            <div><a href="/admin/user/{$comment->user->id}">{$comment->user->name}</a></div>
+                            <div><a href="{'UserAdmin'|link:[id => $comment->user->id]}">{$comment->user->name}</a></div>
                         </li>
                     {/if}
 

--- a/templates/admin/html/content/comment_list.tpl
+++ b/templates/admin/html/content/comment_list.tpl
@@ -64,7 +64,7 @@
 								</div>
 								<div class="col">
 									<div class="mb-2">
-										<a href="/admin/comment/{$comment->id}">{$comment->name}</a>
+                                                                                <a href="{'CommentAdmin'|link:[id => $comment->id]}">{$comment->name}</a>
 										<span class="badge text-bg-round">IP: {$comment->ip}</span>
 										{if !$comment->approved}<a class="approve" href="#">Одобрить</a>{/if}
 									</div>
@@ -77,11 +77,11 @@
 										Комментарий оставлен {$comment->date|date} в {$comment->date|time}
 
 										{if $comment->type == 'product'}
-											к товару <a target="_blank"
-												href="{$config->root_url}/p/{$comment->product->id}#comment_{$comment->id}">{$comment->product->name}</a>
+                                                                                        к товару <a target="_blank"
+                                                                                                href="{'ProductShortId'|linkLang:[id => $comment->product->id]}#comment_{$comment->id}">{$comment->product->name}</a>
 										{elseif $comment->type == 'blog'}
-											к статье <a target="_blank"
-												href="{$config->root_url}/blog/{$comment->post->url}#comment_{$comment->id}">{$comment->post->name}</a>
+                                                                                        к статье <a target="_blank"
+                                                                                                href="{'Post'|linkLang:[url => $comment->post->url]}#comment_{$comment->id}">{$comment->post->name}</a>
 										{/if}
 									</div>
 								</div>

--- a/templates/admin/html/content/parts/menu_part.tpl
+++ b/templates/admin/html/content/parts/menu_part.tpl
@@ -1,25 +1,25 @@
 {block name="tabs"}
 	{if 'blog'|user_access and $route|in_array:[PostAdmin, PostListAdmin, PostNewAdmin]}
 		<li class="mini active">
-			<a href="/admin/posts">Блог</a>
+                        <a href="{'PostListAdmin'|link}">Блог</a>
 		</li>
 	{/if}
 
 	{if 'comment'|user_access and $route|in_array:[CommentListAdmin, CommentAdmin]}
 		<li class="mini active">
-			<a href="/admin/comments">Комментарии</a>
+                        <a href="{'CommentListAdmin'|link}">Комментарии</a>
 		</li>
 	{/if}
 
 	{if 'feedback'|user_access and $route|in_array:[FeedbackListAdmin]}
 		<li class="mini active">
-			<a href="/admin/feedbacks">Обратная связь</a>
+                        <a href="{'FeedbackListAdmin'|link}">Обратная связь</a>
 		</li>
 	{/if}
 
 	{if 'page'|user_access and $route|in_array:[PageListAdmin, PageAdmin]}
 		<li class="mini active">
-			<a href="/admin/pages">Страницы</a>
+                        <a href="{'PageListAdmin'|link}">Страницы</a>
 		</li>
 	{/if}
 {/block}

--- a/templates/admin/html/content/post.tpl
+++ b/templates/admin/html/content/post.tpl
@@ -28,9 +28,9 @@
 							<label class="form-check-label" for="active_checkbox">Активна</label>
 						</div>
 					</div>
-					<a class="out_link" target="_self" href="{$config->root_url}/blog/{$post->url}">Открыть статью на
-						сайте</a>
-				</div>
+                                        <a class="out_link" target="_self" href="{'Post'|linkLang:[url => $post->url]}">Открыть статью на
+                                                сайте</a>
+                                </div>
 
 				<div class="name_row">
 					<span class="item_id">H1</span>

--- a/templates/admin/html/content/post_list.tpl
+++ b/templates/admin/html/content/post_list.tpl
@@ -17,7 +17,7 @@
 			<h1>Нет записей</h1>
 		{/if}
 
-		<a class="add" href="/admin/post">Добавить запись</a>
+                <a class="add" href="{'PostNewAdmin'|link}">Добавить запись</a>
 
 
 		{if $posts || $keyword}
@@ -49,13 +49,13 @@
 							</div>
 
 							<div class="col">
-								<a href="/admin/post/{$post->id}">{$post->name}</a>
+                                                                <a href="{'PostAdmin'|link:[id => $post->id]}">{$post->name}</a>
 								<div class="comment_info">{$post->date|date}</div>
 							</div>
 
 							<div class="icons">
-								<a class="material-icons launch" data-bs-toggle="tooltip" title="Предпросмотр в новом окне"
-									href="{$config->root_url}/blog/{$post->url}" target="_blank"></a>
+                                                                <a class="material-icons launch" data-bs-toggle="tooltip" title="Предпросмотр в новом окне"
+                                                                        href="{'Post'|linkLang:[url => $post->url]}" target="_blank"></a>
 								<i class="enable material-icons visibility" data-bs-toggle="tooltip" title="Активна"></i>
 								<i class="delete material-icons" data-bs-toggle="tooltip" title="Удалить">cancel</i>
 							</div>

--- a/templates/admin/html/order/cart_list.tpl
+++ b/templates/admin/html/order/cart_list.tpl
@@ -11,8 +11,8 @@
 		<div class="header_top">
 			<h1>{if $carts_count}{$carts_count}{else}Нет{/if} корзин{$carts_count|plural:'a':'':'ы'}</h1>
 
-			<a class="add" href="/admin/order">Добавить заказ</a>
-		</div>
+                        <a class="add" href="{'OrderNewAdmin'|link}">Добавить заказ</a>
+                </div>
 
 		<div id="right_menu">
 		</div>

--- a/templates/admin/html/order/order_list.tpl
+++ b/templates/admin/html/order/order_list.tpl
@@ -26,7 +26,7 @@
 				{/if}
 			</h1>
 
-			<a class="add" href="/admin/order">Добавить заказ</a>
+                        <a class="add" href="{'OrderNewAdmin'|link}">Добавить заказ</a>
 
 			{if $orders_count > 0 and 'export'|user_access}
 				<form class="export_btn" method="post" action="/admin/orders/export?{$smarty.server.QUERY_STRING}"

--- a/templates/admin/html/warehouse/move.tpl
+++ b/templates/admin/html/warehouse/move.tpl
@@ -1,4 +1,4 @@
-{* @version 0.1 *}
+{* @version 0.2 *}
 {extends 'wrapper/main.tpl'}
 {include 'warehouse/parts/menu_part.tpl'}
 
@@ -174,11 +174,11 @@
 						</div>
 					{/if}
 
-					<div class="btn_row">
-						<a class="btn btn-light"
-							href="{'PaymentNewAdmin'|link}?cur_type=0&contractor_entity_name=wh_movement&contractor_entity_id={$movement->id}">Добавить
-							платеж</a>
-					</div>
+                                        <div class="btn_row">
+                                                <a class="btn btn-light"
+                                                        href="{'PaymentNewAdmin'|link:[cur_type => 0, contractor_entity_name => 'wh_movement', contractor_entity_id => $movement->id]}">Добавить
+                                                        платеж</a>
+                                        </div>
 
 					{if $movement->payments}
 						<div class="list mt-4">

--- a/templates/admin/html/warehouse/place_list.tpl
+++ b/templates/admin/html/warehouse/place_list.tpl
@@ -8,7 +8,7 @@
     {* Заголовок *}
     <div class="header_top">
         <h1>Склады</h1>
-        <a class="add" href="/admin/warehouse/place">Добавить склад</a>
+        <a class="add" href="{'PlaceNewAdmin'|link}">Добавить склад</a>
     </div>
 
 

--- a/templates/awesome/html/products.tpl
+++ b/templates/awesome/html/products.tpl
@@ -52,9 +52,9 @@
 										<ul>
 											{foreach $c->subcategories as $sc}
 												<li>
-													<a {if $category->id == $sc->id}class="selected" {/if} href="{$sc->url}"
-														data-category="{$sc->id}">{$sc->name}</a>
-												</li>
+                                                                                        <a {if $category->id == $sc->id}class="selected" {/if} href="{'Products'|linkLang:[url => $sc->url]}"
+                                                                                                                data-category="{$sc->id}">{$sc->name}</a>
+                                                                                        </li>
 											{/foreach}
 										</ul>
 									{/if}

--- a/templates/grizlicnc/html/products.tpl
+++ b/templates/grizlicnc/html/products.tpl
@@ -52,9 +52,9 @@
 										<ul>
 											{foreach $c->subcategories as $sc}
 												<li>
-													<a {if $category->id == $sc->id}class="selected" {/if} href="{$sc->url}"
-														data-category="{$sc->id}">{$sc->name}</a>
-												</li>
+                                                                                        <a {if $category->id == $sc->id}class="selected" {/if} href="{'Products'|linkLang:[url => $sc->url]}"
+                                                                                                                data-category="{$sc->id}">{$sc->name}</a>
+                                                                                        </li>
 											{/foreach}
 										</ul>
 									{/if}


### PR DESCRIPTION
## Summary
- use `link`/`linkLang` modifiers instead of raw URLs in templates
- pass params via `link` helper and bump warehouse move template version

## Testing
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68a1546022c08326a063dcb63091f3fa