### PR TITLE
Refactor admin templates to use link modifier

### DIFF
--- a/templates/admin/html/finance/payment.tpl
+++ b/templates/admin/html/finance/payment.tpl
@@ -179,7 +179,7 @@
 
 					<div class='view_entity'>
 						{if !$contractor->entity_id|empty}
-							<a href="/admin/{$contractor->view_name}/{$contractor->entity_id}">{$contractor->entity->name}</a>
+                                                        <a href="{$contractor->view_name|link:[id => $contractor->entity_id]}">{$contractor->entity->name}</a>
 						{/if}
 					</div>
 

--- a/templates/admin/html/finance/payment_list.tpl
+++ b/templates/admin/html/finance/payment_list.tpl
@@ -145,8 +145,8 @@
 
                                        {if !$p->contractor->entity->name|empty}
                                           <div class="notice">
-                                             <a
-                                                href="/admin/{$p->contractor->view_name}/{$p->contractor->entity_id}">{$p->contractor->entity->name}</a>
+                                               <a
+                                                  href="{$p->contractor->view_name|link:[id => $p->contractor->entity_id]}">{$p->contractor->entity->name}</a>
                                           </div>
                                        {/if}
                                     </div>

--- a/templates/admin/html/settings/language_list.tpl
+++ b/templates/admin/html/settings/language_list.tpl
@@ -7,7 +7,7 @@
 
     <div class="header_top">
         <h1>{$meta_title}</h1>
-        <a class="add" href="/admin/language">Добавить язык</a>
+        <a class="add" href="{'LanguageNewAdmin'|link}">Добавить язык</a>
     </div>
 
     <div id="main_list">
@@ -24,7 +24,7 @@
 
                             <div class="col row">
                                 <div class="col-12 col-sm-8 name">
-                                    <a href="/admin/language/{$language->id}">{$language->name}</a>
+                                    <a href="{'LanguageAdmin'|link:[id => $language->id]}">{$language->name}</a>
                                     <span class="badge text-bg-secondary ms-2">{$language->code}</span>
                                 </div>
                                 <div class="col-12 col-sm-4 text-end">

--- a/templates/admin/html/user/coupon_list.tpl
+++ b/templates/admin/html/user/coupon_list.tpl
@@ -11,7 +11,7 @@
 		{else}
 			<h1>Нет купонов</h1>
 		{/if}
-		<a class="add" href="/admin/user/coupon">Новый купон</a>
+                <a class="add" href="{'CouponNewAdmin'|link}">Новый купон</a>
 	</div>
 
 
@@ -32,7 +32,7 @@
 
 							<div class="col row">
 								<div class="col-12 col-sm-4">
-									<a href="/admin/user/coupon/{$coupon->id}">{$coupon->code}</a>
+                                                                        <a href="{'CouponAdmin'|link:[id => $coupon->id]}">{$coupon->code}</a>
 								</div>
 
 								<div class="col-12 col-sm-4">

--- a/templates/admin/html/user/group_list.tpl
+++ b/templates/admin/html/user/group_list.tpl
@@ -7,7 +7,7 @@
 
 	<div class="header_top">
 		<h1>Группы пользователей</h1>
-		<a class="add" href="/admin/user/group">Добавить группу</a>
+                <a class="add" href="{'GroupNewAdmin'|link}">Добавить группу</a>
 	</div>
 
 
@@ -33,7 +33,7 @@
 
 						<div class="col row">
 							<div class="col-12 col-sm-10 name">
-								<a href="/admin/user/group/{$group->id}">{$group->name}</a>
+                                                                <a href="{'GroupAdmin'|link:[id => $group->id]}">{$group->name}</a>
 							</div>
 
 							<div class="col-12 col-sm-2 text-end">

--- a/templates/admin/html/user/mailing_list.tpl
+++ b/templates/admin/html/user/mailing_list.tpl
@@ -14,7 +14,7 @@
 					Еще нет сообщений
 				{/if}
 			</h1>
-			<a class="add" href="/admin/user/mailing">Новый Сообщение</a>
+                        <a class="add" href="{'MailingNewAdmin'|link}">Новый Сообщение</a>
 		</div>
 
 

--- a/templates/admin/html/user/notifier_list.tpl
+++ b/templates/admin/html/user/notifier_list.tpl
@@ -7,7 +7,7 @@
 
 	<div class="header_top">
 		<h1>Оповещения пользователей</h1>
-		<a class="add" href="/admin/user/notifier">Добавить способ оповещения</a>
+                <a class="add" href="{'NotifierNewAdmin'|link}">Добавить способ оповещения</a>
 	</div>
 
 
@@ -30,7 +30,7 @@
 							</div>
 
 							<div class="col">
-								<a href="/admin/user/notifier/{$notifier->id}">{$notifier->name}</a>
+                                                                <a href="{'NotifierAdmin'|link:[id => $notifier->id]}">{$notifier->name}</a>
 								<div class="notice">{$notifier->comment}</div>
 							</div>
 

--- a/templates/admin/html/user/parts/menu_part.tpl
+++ b/templates/admin/html/user/parts/menu_part.tpl
@@ -2,33 +2,33 @@
 
 	{if 'user'|user_access and $route|in_array:[UserListAdmin, UserAdmin, UserSettingsAdmin, GroupListAdmin, GroupAdmin, GroupNewAdmin]}
 		<li class="mini {if $route|in_array:[UserListAdmin, UserAdmin, UserSettingsAdmin]}active{/if}">
-			<a href="/admin/users">Покупатели</a>
+                        <a href="{'UserListAdmin'|link}">Покупатели</a>
 		</li>
 	{/if}
 
 	{if 'user_group'|user_access and $route|in_array:[GroupListAdmin, GroupAdmin, GroupNewAdmin, UserListAdmin, UserAdmin, UserSettingsAdmin]}
 		<li class="right mini {if $route|in_array:[GroupListAdmin, GroupAdmin, GroupNewAdmin]}active{/if}">
-			<a href="/admin/user/groups">Группы</a>
+                        <a href="{'GroupListAdmin'|link}">Группы</a>
 		</li>
 	{/if}
 
 	{if 'user_notifier'|user_access and $route|in_array:[MailingNewAdmin, MailingAdmin, MailingListAdmin, NotifierAdmin, NotifierListAdmin, NotifierNewAdmin, MailTemplateNewAdmin, MailTemplateListAdmin, MailTemplateAdmin]}
 		<li class="mini {if $route|in_array:[MailingNewAdmin, MailingAdmin, MailingListAdmin]}active{/if}">
-			<a href="/admin/user/mailings">Список рассылки</a>
+                        <a href="{'MailingListAdmin'|link}">Список рассылки</a>
 		</li>
 
 		<li class="right mini {if $route|in_array:[MailTemplateNewAdmin, MailTemplateListAdmin, MailTemplateAdmin]}active{/if}">
-			<a href="/admin/user/mailing/templates">Шаблоны</a>
+                        <a href="{'MailTemplateListAdmin'|link}">Шаблоны</a>
 		</li>
 
 		<li class="right mini {if $route|in_array:[NotifierAdmin, NotifierListAdmin, NotifierNewAdmin]}active{/if}">
-			<a href="/admin/user/notifiers">Оповещения</a>
+                        <a href="{'NotifierListAdmin'|link}">Оповещения</a>
 		</li>
 	{/if}
 
 	{if 'user_coupon'|user_access and $route|in_array:[CouponListAdmin, CouponAdmin, CouponNewAdmin]}
 		<li class="mini active">
-			<a href="/admin/user/coupons">Купоны</a>
+                        <a href="{'CouponListAdmin'|link}">Купоны</a>
 		</li>
 	{/if}
 

--- a/templates/admin/html/user/parts/submenu_part.tpl
+++ b/templates/admin/html/user/parts/submenu_part.tpl
@@ -4,13 +4,13 @@
 		<ul id="submenu" class="submenu">
 			{if 'user_settings'|user_access and $current_user->id}
 				<li {if $route == 'UserAdmin'}class="active" {/if}>
-					<a href="/admin/user/{$current_user->id}">Информация</a>
+                                        <a href="{'UserAdmin'|link:[id => $current_user->id]}">Информация</a>
 				</li>
 			{/if}
 
 			{if 'user_settings'|user_access and $current_user->id}
 				<li {if $route == 'UserSettingsAdmin'}class="active" {/if}>
-					<a href="/admin/user/{$current_user->id}/settings">Настройки сотрудника</a>
+                                        <a href="{'UserSettingsAdmin'|link:[id => $current_user->id]}">Настройки сотрудника</a>
 				</li>
 			{/if}
 

--- a/templates/admin/html/user/user_list.tpl
+++ b/templates/admin/html/user/user_list.tpl
@@ -107,7 +107,7 @@
 
 								<div class="col row">
 									<div class="col-12 col-sm-4">
-										<a href="/admin/user/{$u->id}">{if $u->name}{$u->name}{else}-{/if}</a>
+                                                                                <a href="{'UserAdmin'|link:[id => $u->id]}">{if $u->name}{$u->name}{else}-{/if}</a>
 										<div class="notice">{$groups[$u->group->id]->name}</div>
 									</div>
 


### PR DESCRIPTION
## Summary
- use `link` modifier for admin routes in templates
- remove hardcoded URLs for dynamic route generation

## Testing
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68a15c570e6c8326b8e3dbde0cc275a5