### PR TITLE
Add LanguageAutoDetect extension

### DIFF
--- a/hugashop/crm/Extensions/LanguageAutoDetect/Controller/LanguageAutoDetectController.php
+++ b/hugashop/crm/Extensions/LanguageAutoDetect/Controller/LanguageAutoDetectController.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\LanguageAutoDetect\Controller;
+
+use App\Controller\BaseFrontController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use HugaShop\Extensions\LanguageAutoDetect\LanguageAutoDetect;
+use HugaShop\Models\Localization\Language;
+use HugaShop\Services\Design;
+use HugaShop\Services\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class LanguageAutoDetectController extends BaseFrontController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/LanguageAutoDetect/switcher', name: 'ExtLanguageAutoDetectSwitcher', priority: 20)]
+    public function switcher(): Response
+    {
+        $matchCode = Request::get('match');
+        $currentCode = Request::get('current');
+
+        $languages = Language::getLanguages();
+        $match = $languages->firstWhere('code', $matchCode);
+        $current = $languages->firstWhere('code', $currentCode);
+
+        if (empty($match) || empty($current)) {
+            return new Response('', 404);
+        }
+
+        $translateFilePath = LanguageAutoDetect::getExtensionDir() . 'translations/messages.' . Design::$locale . '.yaml';
+        if (file_exists($translateFilePath)) {
+            Design::$Translator->addResource('yaml', $translateFilePath, Design::$locale);
+        }
+
+        Design::assign('match_language', $match);
+        Design::assign('current_language', $current);
+
+        return $this->fetchExtResponse('modal.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/LanguageAutoDetect/LanguageAutoDetect.php
+++ b/hugashop/crm/Extensions/LanguageAutoDetect/LanguageAutoDetect.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.1
+ *
+ * Detect browser language and suggest switching.
+ */
+
+namespace HugaShop\Extensions\LanguageAutoDetect;
+
+use HugaShop\Extensions\BaseExtension;
+use HugaShop\Models\Localization\Language;
+use HugaShop\Services\Design;
+
+final class LanguageAutoDetect extends BaseExtension
+{
+    /**
+     * Get block template
+     */
+    public static function getFrontBodyTemplate()
+    {
+        if (self::isEnabled()) {
+            // If translation file exists
+            $translate_file_path = self::getExtensionDir() . 'translations/messages.' . Design::$locale . '.yaml';
+            if (file_exists($translate_file_path)) {
+                Design::$Translator->addResource('yaml', $translate_file_path, Design::$locale);
+            }
+
+            Design::assign('LanguageAutoDetect_languages', Language::getLanguages());
+            return self::fetchTemplate('switcher.tpl');
+        }
+    }
+}

--- a/hugashop/crm/Extensions/LanguageAutoDetect/settings.yaml
+++ b/hugashop/crm/Extensions/LanguageAutoDetect/settings.yaml
@@ -1,0 +1,9 @@
+name: "Автоматическое определение языка"
+description: "Предлагает переключиться на язык браузера пользователя, если он доступен на сайте"
+settings_params:
+  - {
+      variable: enabled,
+      name: "Включено",
+      options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }],
+    }
+version: 1.1

--- a/hugashop/crm/Extensions/LanguageAutoDetect/templates/modal.tpl
+++ b/hugashop/crm/Extensions/LanguageAutoDetect/templates/modal.tpl
@@ -1,0 +1,18 @@
+{* LanguageAutoDetect modal *}
+<div class="language-auto-detect-modal p-4 text-center">
+    <p class="mb-3">{'Switch to %language%?'|trans|replace:'%language%':$match_language->name}</p>
+    <button type="button" class="btn btn-secondary me-2 js-current">{$current_language->name}</button>
+    <button type="button" class="btn btn-primary js-switch">{$match_language->name}</button>
+</div>
+<script>
+    (function () {
+        $('.js-current').on('click', function () {
+            $.fancybox.close();
+        });
+        $('.js-switch').on('click', function () {
+            var url = new URL(window.location.href);
+            url.searchParams.set('lang', '{$match_language->code}');
+            window.location.href = url.toString();
+        });
+    })();
+</script>

--- a/hugashop/crm/Extensions/LanguageAutoDetect/templates/switcher.tpl
+++ b/hugashop/crm/Extensions/LanguageAutoDetect/templates/switcher.tpl
@@ -1,0 +1,37 @@
+{* LanguageAutoDetect script *}
+<script>
+    (function () {
+        var languages = {$LanguageAutoDetect_languages|json_encode|raw};
+        var currentLang = '{$current_language->code}';
+        var storageKey = 'language_auto_detect_seen';
+
+        if (localStorage.getItem(storageKey)) {
+            return;
+        }
+
+        var browserLang = navigator.language || navigator.userLanguage;
+        if (!browserLang) {
+            return;
+        }
+        browserLang = browserLang.split('-')[0];
+
+        var match = languages.find(function (item) {
+            return item.code === browserLang;
+        });
+
+        if (!match || match.code === currentLang) {
+            return;
+        }
+
+        $.fancybox.open({
+            type: 'ajax',
+            src: "{'ExtLanguageAutoDetectSwitcher'|linkLang|escape:'javascript'}" + '?match=' + match.code + '&current=' + currentLang,
+            touch: false,
+            closeExisting: true,
+            afterClose: function () {
+                localStorage.setItem(storageKey, 1);
+                asignFancyAjax();
+            }
+        });
+    })();
+</script>

--- a/hugashop/crm/Extensions/LanguageAutoDetect/translations/messages.en.yaml
+++ b/hugashop/crm/Extensions/LanguageAutoDetect/translations/messages.en.yaml
@@ -1,0 +1,1 @@
+"Switch to %language%?": "Switch to %language%?"

--- a/hugashop/crm/Extensions/LanguageAutoDetect/translations/messages.ru.yaml
+++ b/hugashop/crm/Extensions/LanguageAutoDetect/translations/messages.ru.yaml
@@ -1,0 +1,1 @@
+"Switch to %language%?": "Переключить язык на %language%?"

--- a/hugashop/crm/Extensions/LanguageAutoDetect/translations/messages.uk.yaml
+++ b/hugashop/crm/Extensions/LanguageAutoDetect/translations/messages.uk.yaml
@@ -1,0 +1,1 @@
+"Switch to %language%?": "Переключити мову на %language%?"


### PR DESCRIPTION
## Summary
- add LanguageAutoDetect extension to detect browser language and suggest switching
- open AJAX modal via fancybox to switch language
- rebind Fancybox AJAX handlers after modal closes

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a40192d95483269b7ff98606fb6edb