### PR TITLE
feat: add timer help offer extension

### DIFF
--- a/hugashop/crm/Extensions/TimerGetHelpOffer/Controller/HelpOfferController.php
+++ b/hugashop/crm/Extensions/TimerGetHelpOffer/Controller/HelpOfferController.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\TimerGetHelpOffer\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Helper;
+use HugaShop\Services\Secure;
+use HugaShop\Services\Request;
+use HugaShop\Services\NotifierFactory;
+use App\Controller\BaseFrontController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Extensions\TimerGetHelpOffer\Models\HelpOffer;
+use HugaShop\Extensions\TimerGetHelpOffer\Services\NotifyService;
+
+final class HelpOfferController extends BaseFrontController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/TimerGetHelpOffer/form', name: 'ExtTimerGetHelpOfferForm', priority: 21)]
+    public function form(): Response
+    {
+        if (!empty($request = Secure::getInputAcces(HelpOffer::getFields()))) {
+            $hasConsent = Request::post('personal_data');
+            if ($hasConsent && Helper::checkCaptcha()) {
+                $request->ip         = $_SERVER['REMOTE_ADDR'];
+                $request->user_agent = $_SERVER['HTTP_USER_AGENT'];
+                $request             = HelpOffer::createOne($request);
+
+                NotifierFactory::sendToManagers([
+                    NotifyService::class,
+                    'offerToAdmin'
+                ], [
+                    'request' => $request
+                ]);
+
+                return $this->fetchExtResponse('form.tpl', 'request_sent');
+            } else {
+                Design::assign('error', $hasConsent ? 'captcha' : 'personal_data');
+            }
+        }
+
+        Design::assign('request', $request);
+        Design::assign('personal_data', Request::post('personal_data'));
+
+        return $this->fetchExtResponse('form.tpl', 'help_offer');
+    }
+}

--- a/hugashop/crm/Extensions/TimerGetHelpOffer/Controller/HelpOfferItemController.php
+++ b/hugashop/crm/Extensions/TimerGetHelpOffer/Controller/HelpOfferItemController.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\TimerGetHelpOffer\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Helper;
+use App\Controller\BaseAdminController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Extensions\TimerGetHelpOffer\Models\HelpOffer;
+
+final class HelpOfferItemController extends BaseAdminController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/TimerGetHelpOffer/{id}', requirements: ['id' => '\\d+'], name: 'ExtTimerGetHelpOfferItem', priority: 20)]
+    public function item(int $id): Response
+    {
+        $this->checkAdminAccess('extension');
+
+        if (!$request = HelpOffer::getOne($id)) {
+            return $this->redirectToRoute('ExtTimerGetHelpOfferList');
+        }
+
+        if (!empty($request->user_agent)) {
+            $request->user_agent = Helper::getUserAgentInfo($request->user_agent);
+        }
+
+        Design::assign('request', $request);
+        Design::assign('extension', $this->getExtension());
+
+        return $this->fetchExtResponse('item.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/TimerGetHelpOffer/Controller/HelpOfferListController.php
+++ b/hugashop/crm/Extensions/TimerGetHelpOffer/Controller/HelpOfferListController.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\TimerGetHelpOffer\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Secure;
+use HugaShop\Services\Request;
+use App\Services\PaginationService;
+use App\Controller\BaseAdminController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Extensions\TimerGetHelpOffer\Models\HelpOffer;
+
+final class HelpOfferListController extends BaseAdminController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/TimerGetHelpOffer', name: 'ExtTimerGetHelpOfferList', priority: 20)]
+    public function index(): Response
+    {
+        $this->checkAdminAccess('extension');
+
+        if (Secure::checkCSRF()) {
+            $ids = Request::post('check');
+            if (is_array($ids)) {
+                if (Request::post('action') === 'delete') {
+                    HelpOffer::deleteOne($ids);
+                }
+            }
+        }
+
+        $filter         = PaginationService::initFilter();
+        $requests       = HelpOffer::getList($filter, order: ['created_at', 'desc']);
+        $requests_count = HelpOffer::getCount($filter);
+
+        Design::assign('requests', $requests);
+        Design::assign('pagination', PaginationService::getPagination($requests_count, $filter));
+        Design::assign('extension', $this->getExtension());
+
+        return $this->fetchExtResponse('list.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/TimerGetHelpOffer/Models/HelpOffer.php
+++ b/hugashop/crm/Extensions/TimerGetHelpOffer/Models/HelpOffer.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\TimerGetHelpOffer\Models;
+
+use HugaShop\Extensions\BaseExtensionModel;
+
+final class HelpOffer extends BaseExtensionModel
+{
+    public $timestamps = true;
+
+    protected static $table_fields = [
+        'id'         => ['type' => 'int',     'extra' => 'AUTO_INCREMENT'],
+        'name'       => ['type' => 'varchar', 'req' => true],
+        'phone'      => ['type' => 'varchar', 'req' => true],
+        'email'      => ['type' => 'varchar'],
+        'user_agent' => ['type' => 'varchar', 'access' => false],
+        'ip'         => ['type' => 'varchar', 'access' => false, 'length' => 20],
+    ];
+}

--- a/hugashop/crm/Extensions/TimerGetHelpOffer/Services/NotifyService.php
+++ b/hugashop/crm/Extensions/TimerGetHelpOffer/Services/NotifyService.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\TimerGetHelpOffer\Services;
+
+use HugaShop\Services\Design;
+use HugaShop\Extensions\BaseExtensionTrait;
+
+final class NotifyService
+{
+    use BaseExtensionTrait;
+
+    /**
+     * Email message to admin
+     */
+    public static function offerToAdmin(string $module_name, array &$message_data)
+    {
+        if (empty($message_data['request'])) {
+            return;
+        }
+
+        $template_path = self::getTemplatePath(strtolower($module_name) . '_offerToAdmin.tpl');
+        if (!file_exists($template_path)) {
+            return;
+        }
+
+        Design::assign('request', $message_data['request']);
+
+        $message                 = Design::fetch($template_path);
+        $message_data['subject'] = Design::getTemplateVars('subject');
+
+        return $message;
+    }
+}

--- a/hugashop/crm/Extensions/TimerGetHelpOffer/TimerGetHelpOffer.php
+++ b/hugashop/crm/Extensions/TimerGetHelpOffer/TimerGetHelpOffer.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\TimerGetHelpOffer;
+
+use HugaShop\Extensions\BaseExtension;
+
+final class TimerGetHelpOffer extends BaseExtension
+{
+    /**
+     * Render scripts on front pages
+     */
+    public static function getFrontBodyTemplate()
+    {
+        if (self::isEnabled()) {
+            return self::fetchTemplate('scripts.tpl');
+        }
+        return;
+    }
+}

--- a/hugashop/crm/Extensions/TimerGetHelpOffer/settings.yaml
+++ b/hugashop/crm/Extensions/TimerGetHelpOffer/settings.yaml
@@ -1,0 +1,22 @@
+name: "Предложение помощи в выборе товара"
+description: "Всплывающее предложение помощи с выбором товара"
+settings_params:
+  - {
+      variable: enabled,
+      name: "Включено",
+      options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }],
+    }
+  - {
+      variable: timer,
+      name: "Таймер показа (сек.)",
+      placeholder: "30",
+    }
+  - {
+      variable: show_on_leave,
+      name: "Показ при уходе",
+      options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }],
+    }
+notifier:
+  admin:
+    - offerToAdmin: "Заявка на помощь с выбором товара"
+version: 1.0

--- a/hugashop/crm/Extensions/TimerGetHelpOffer/templates/email_offerToAdmin.tpl
+++ b/hugashop/crm/Extensions/TimerGetHelpOffer/templates/email_offerToAdmin.tpl
@@ -1,0 +1,21 @@
+{$subject="Заявка на помощь с выбором товара"}
+
+<h1 style='font-weight:normal;'>Заявка на помощь с выбором товара</h1>
+<table cellpadding=6 cellspacing=0 style='border-collapse: collapse;'>
+    <tr>
+        <td style='padding:6px;width:170;background-color:#f0f0f0;border:1px solid #e0e0e0;font-family:arial;'>Имя</td>
+        <td style='padding:6px;width:330;background-color:#ffffff;border:1px solid #e0e0e0;font-family:arial;'>{$request->name}</td>
+    </tr>
+    <tr>
+        <td style='padding:6px;background-color:#f0f0f0;border:1px solid #e0e0e0;font-family:arial;'>Телефон</td>
+        <td style='padding:6px;background-color:#ffffff;border:1px solid #e0e0e0;font-family:arial;'>{$request->phone}</td>
+    </tr>
+    <tr>
+        <td style='padding:6px;background-color:#f0f0f0;border:1px solid #e0e0e0;font-family:arial;'>Email</td>
+        <td style='padding:6px;background-color:#ffffff;border:1px solid #e0e0e0;font-family:arial;'><a href='mailto:{$request->email}?subject={$settings->domain}'>{$request->email}</a></td>
+    </tr>
+    <tr>
+        <td style='padding:6px;background-color:#f0f0f0;border:1px solid #e0e0e0;font-family:arial;'>IP</td>
+        <td style='padding:6px;background-color:#ffffff;border:1px solid #e0e0e0;font-family:arial;'>{$request->ip}</td>
+    </tr>
+</table>

--- a/hugashop/crm/Extensions/TimerGetHelpOffer/templates/form.tpl
+++ b/hugashop/crm/Extensions/TimerGetHelpOffer/templates/form.tpl
@@ -1,0 +1,50 @@
+{block name=help_offer}
+    <div id="help_offer">
+        <div class="mb-4">
+            <h1>Нужна помощь с выбором товара?</h1>
+            <p>Заполните форму ниже и наши специалисты свяжутся с Вам в ближайшее время</p>
+        </div>
+
+        {if $error}
+            <div class="alert alert-danger">
+                {if $error=='captcha'}Подтвердите что вы не робот{elseif $error=='personal_data'}Вы должны согласиться с обработкой персональных данных{/if}
+            </div>
+        {/if}
+
+        <form method="post" action="{'ExtTimerGetHelpOfferForm'|link}" class="needs-validation">
+            {getCSRFInput}
+            <div class="mb-3">
+                <label class="form-label" for="hgo_name">Имя</label>
+                <input class="form-control {if 'name'|in_array:$form_invalid}is-invalid{/if}" type="text" name="name" id="hgo_name" value="{$request->name}">
+                <div class="invalid-feedback">Введите имя</div>
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="hgo_phone">Телефон</label>
+                <input class="form-control {if 'phone'|in_array:$form_invalid}is-invalid{/if}" type="text" name="phone" id="hgo_phone" value="{$request->phone}">
+                <div class="invalid-feedback">Введите телефон</div>
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="hgo_email">Email</label>
+                <input class="form-control" type="email" name="email" id="hgo_email" value="{$request->email}">
+            </div>
+            <div class="mb-3">
+                <div class="g-recaptcha" data-sitekey="{$config->recaptcha->public_key}"></div>
+            </div>
+            <div class="form-check mb-3">
+                <input class="form-check-input {if $error=='personal_data'}is-invalid{/if}" type="checkbox" value="1" id="hgo_personal_data" name="personal_data" {if $personal_data}checked{/if}>
+                <label class="form-check-label" for="hgo_personal_data">Я согласен на обработку персональных данных</label>
+                <div class="invalid-feedback">Нужно согласие</div>
+            </div>
+            <div class="text-end">
+                <button class="btn btn-primary" type="submit">Отправить</button>
+            </div>
+        </form>
+        <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+    </div>
+{/block}
+
+{block name=request_sent}
+    <div id="help_offer_sent">
+        <div class="alert alert-success">Спасибо, ваша заявка отправлена.</div>
+    </div>
+{/block}

--- a/hugashop/crm/Extensions/TimerGetHelpOffer/templates/item.tpl
+++ b/hugashop/crm/Extensions/TimerGetHelpOffer/templates/item.tpl
@@ -1,0 +1,57 @@
+{extends 'wrapper/main.tpl'}
+{include 'extension/parts/menu_part.tpl'}
+
+{$meta_title="Заявка #{$request->id}"}
+
+{block name=content }
+    <div class="header_top">
+        <h1>Заявка #{$request->id}</h1>
+    </div>
+    <div class="row gx-5">
+        <div class="col-lg-6">
+            <ul class="property_block">
+                <li>
+                    <div class="col-form-label">Имя:</div>
+                    <div class="col-form-label">{$request->name}</div>
+                </li>
+                <li>
+                    <div class="col-form-label">Телефон:</div>
+                    <div class="col-form-label">{$request->phone}</div>
+                </li>
+                <li>
+                    <div class="col-form-label">Email:</div>
+                    <div class="col-form-label">{$request->email}</div>
+                </li>
+                <li>
+                    <div class="col-form-label">Дата:</div>
+                    <div class="col-form-label">{$request->created_at|date} {$request->created_at|time}</div>
+                </li>
+
+                <li>
+                    <div class="col-form-label"></div>
+                    <div class="col-form-label">
+                        <div class="list-group">
+                            <div class="list-group-item">
+                                <div>IP: {$request->ip}</div>
+                                <div>
+                                    <a class="badge text-bg-secondary" href='https://www.ipaddress.com/ipv4/{$request->ip}' target="_blank">где это?</a>
+                                </div>
+                            </div>
+
+                            {if !$request->user_agent|empty}
+                                <div class="list-group-item">
+                                    <div class="col-6">{$request->user_agent->os} {$request->user_agent->os_version}</div>
+                                    <span class="badge text-bg-secondary">{$request->user_agent->device_type}</span>
+                                </div>
+                                <div class="list-group-item">
+                                    <div class="col-6">{$request->user_agent->browser}</div>
+                                    <span class="badge text-bg-secondary">{$request->user_agent->device}</span>
+                                </div>
+                            {/if}
+                        </div>
+                    </div>
+                </li>
+            </ul>
+        </div>
+    </div>
+{/block}

--- a/hugashop/crm/Extensions/TimerGetHelpOffer/templates/list.tpl
+++ b/hugashop/crm/Extensions/TimerGetHelpOffer/templates/list.tpl
@@ -1,0 +1,55 @@
+{extends 'wrapper/main.tpl'}
+{include 'extension/parts/menu_part.tpl'}
+
+{$meta_title='Заявки на помощь в выборе товара'}
+
+{block name=content}
+    <div class="header_top">
+        {if $requests_count}
+            <h1>{$requests_count} {$requests_count|plural:'заявка':'заявок':'заявки'}</h1>
+        {else}
+            <h1>Нет заявок</h1>
+        {/if}
+    </div>
+    <div id="main_list">
+        {if $requests->isNotEmpty()}
+            {include file='parts/pagination.tpl'}
+            <form method="post" class="list_form">
+                {getCSRFInput}
+                <div class="list">
+                    {foreach $requests as $r}
+                        <div class="list_row">
+                            <div class="checkbox">
+                                <input class="form-check-input" type="checkbox" name="check[]" value="{$r->id}" />
+                            </div>
+
+                            <div class="col">
+                                <a href="{'ExtTimerGetHelpOfferItem'|link:[id => $r->id]}">{$r->name}</a>
+                                <div class="notice">{$r->phone} {$r->email}</div>
+                                <span class="badge text-bg-round">{$r->created_at|date} {$r->created_at|time}</span>
+                            </div>
+
+                            <div class="icons">
+                                <i class="delete material-icons" data-bs-toggle="tooltip" title="Удалить">cancel</i>
+                            </div>
+                        </div>
+                    {/foreach}
+                </div>
+
+                <div id="action">
+                    <span id='check_all' class='dash_link'>Выбрать все</span>
+                    <span id=select>
+                        <select class="form-select" name="action">
+                            <option value="">Выбрать действие</option>
+                            <option value="delete">Удалить</option>
+                        </select>
+                    </span>
+                    <button class="btn btn-primary apply" id="apply_action" type="submit">Применить</button>
+                </div>
+            </form>
+            {include file='parts/pagination.tpl'}
+        {else}
+            Нет заявок
+        {/if}
+    </div>
+{/block}

--- a/hugashop/crm/Extensions/TimerGetHelpOffer/templates/scripts.tpl
+++ b/hugashop/crm/Extensions/TimerGetHelpOffer/templates/scripts.tpl
@@ -1,0 +1,43 @@
+<script type="module">
+    import { asignFancyAjax } from "{'js/common.js'|asset}";
+
+    let offer_link   = "{'ExtTimerGetHelpOfferForm'|link}";
+    let showTimer    = {$TimerGetHelpOffer->timer|default:0} * 1000;
+    let showOnLeave  = {$TimerGetHelpOffer->show_on_leave|default:0};
+    let offerShown   = false;
+
+    function openOffer() {
+        if (offerShown) {
+            return;
+        }
+        offerShown = true;
+        $.fancybox.open({
+            type: 'ajax',
+            src: offer_link,
+            ajax: {
+                settings: {
+                    method: 'POST',
+                    data: {
+                        csrf: window.csrf
+                    }
+                }
+            },
+            touch: false,
+            closeExisting: true,
+            afterShow: asignFancyAjax
+        });
+    }
+
+    $(function() {
+        if (showTimer > 0) {
+            setTimeout(openOffer, showTimer);
+        }
+        if (showOnLeave) {
+            document.addEventListener('visibilitychange', function() {
+                if (document.hidden) {
+                    openOffer();
+                }
+            }, { once: true });
+        }
+    });
+</script>


### PR DESCRIPTION
## Summary
- add TimerGetHelpOffer extension with timed popup help form
- store help requests and list/view them in admin panel
- add notifier and settings for timer and on-leave trigger

## Testing
- `php -l hugashop/crm/Extensions/TimerGetHelpOffer/TimerGetHelpOffer.php`
- `php -l hugashop/crm/Extensions/TimerGetHelpOffer/Models/HelpOffer.php`
- `php -l hugashop/crm/Extensions/TimerGetHelpOffer/Controller/HelpOfferController.php`
- `php -l hugashop/crm/Extensions/TimerGetHelpOffer/Controller/HelpOfferListController.php`
- `php -l hugashop/crm/Extensions/TimerGetHelpOffer/Controller/HelpOfferItemController.php`
- `php -l hugashop/crm/Extensions/TimerGetHelpOffer/Services/NotifyService.php`
- `composer dump-autoload`

------
https://chatgpt.com/codex/tasks/task_e_68a4077238cc8326bff5479775c43486