### PR TITLE
feat(timer-get-help-offer): skip captcha for logged users

### DIFF
--- a/hugashop/crm/Extensions/TimerGetHelpOffer/Controller/HelpOfferController.php
+++ b/hugashop/crm/Extensions/TimerGetHelpOffer/Controller/HelpOfferController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.1
+ * @version 1.2
  */
 
 namespace HugaShop\Extensions\TimerGetHelpOffer\Controller;
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use HugaShop\Extensions\TimerGetHelpOffer\Models\HelpOffer;
 use HugaShop\Extensions\TimerGetHelpOffer\Services\NotifyService;
+use HugaShop\Models\User\User;
 
 final class HelpOfferController extends BaseFrontController
 {
@@ -30,10 +31,11 @@ final class HelpOfferController extends BaseFrontController
     {
 
         $hasConsent = Request::post('personal_data');
+        $isLogged   = User::isLoggedIn();
 
         if (!empty($request = Secure::getInputAcces(HelpOffer::getFields()))) {
 
-            if ($hasConsent && Helper::checkCaptcha()) {
+            if ($hasConsent && ($isLogged || Helper::checkCaptcha())) {
                 $request->ip         = $_SERVER['REMOTE_ADDR'];
                 $request->user_agent = $_SERVER['HTTP_USER_AGENT'];
                 $request             = HelpOffer::createOne($request);

--- a/hugashop/crm/Extensions/TimerGetHelpOffer/templates/form.tpl
+++ b/hugashop/crm/Extensions/TimerGetHelpOffer/templates/form.tpl
@@ -31,9 +31,11 @@
                 <label class="form-label" for="hgo_email">Email</label>
                 <input class="form-control" type="email" name="email" id="hgo_email" value="{$request->email}">
             </div>
-            <div class="mb-3">
-                <div class="g-recaptcha" data-sitekey="{$config->recaptcha->public_key}"></div>
-            </div>
+            {if $user|empty}
+                <div class="mb-3">
+                    <div class="g-recaptcha" data-sitekey="{$config->recaptcha->public_key}"></div>
+                </div>
+            {/if}
 
             <div class="form-check form-switch mb-3">
                 <input class="form-check-input {if $error=='personal_data'}is-invalid{/if}" type="checkbox" role="switch"
@@ -46,7 +48,9 @@
                 <button class="btn btn-primary" type="submit">Отправить</button>
             </div>
         </form>
-        <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+        {if $user|empty}
+            <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+        {/if}
     </div>
 {/block}
 


### PR DESCRIPTION
## Summary
- bypass reCAPTCHA in TimerGetHelpOffer when a customer is authenticated
- show reCAPTCHA widget only to guests

## Testing
- `php -l hugashop/crm/Extensions/TimerGetHelpOffer/Controller/HelpOfferController.php`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f32f734083268243f004d0851184