### PR TITLE
Add SubscribeOffer extension for coupon newsletter modal

### DIFF
--- a/hugashop/crm/Extensions/SubscribeOffer/Controller/SubscribeOfferController.php
+++ b/hugashop/crm/Extensions/SubscribeOffer/Controller/SubscribeOfferController.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\SubscribeOffer\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Models\User\User;
+use HugaShop\Services\Request;
+use App\Controller\BaseFrontController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Extensions\SubscribeOffer\Models\SubscribeOffer;
+use stdClass;
+
+final class SubscribeOfferController extends BaseFrontController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/SubscribeOffer/form', name: 'ExtSubscribeOfferForm', priority: 20)]
+    public function form(): Response
+    {
+        $id    = Request::post('id', 'int');
+        $email = Request::post('email', 'string');
+        $error = null;
+
+        if ($email && $id) {
+            if (!User::checkEmailExists($email) && !SubscribeOffer::getOne(['email' => $email])) {
+                SubscribeOffer::updateOne($id, ['email' => $email]);
+                Design::assign('coupon', $this->getExtension()->coupon_code);
+                return $this->fetchExtResponse('form.tpl', 'request_sent');
+            } else {
+                $error = 'email_exists';
+            }
+        } elseif (!empty($page = Request::post('page', 'string'))) {
+            $request             = new stdClass();
+            $request->ip         = $_SERVER['REMOTE_ADDR'];
+            $request->user_agent = $_SERVER['HTTP_USER_AGENT'];
+            $request->page       = $page;
+            $id                  = SubscribeOffer::createOne($request)?->id;
+        }
+
+        Design::assign('id', $id);
+        Design::assign('email', $email);
+        Design::assign('error', $error);
+
+        return $this->fetchExtResponse('form.tpl', 'subscribe_offer');
+    }
+}

--- a/hugashop/crm/Extensions/SubscribeOffer/Controller/SubscribeOfferItemController.php
+++ b/hugashop/crm/Extensions/SubscribeOffer/Controller/SubscribeOfferItemController.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\SubscribeOffer\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Helper;
+use App\Controller\BaseAdminController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Extensions\SubscribeOffer\Models\SubscribeOffer;
+
+final class SubscribeOfferItemController extends BaseAdminController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/SubscribeOffer/{id}', requirements: ['id' => '\\d+'], name: 'ExtSubscribeOfferItem', priority: 20)]
+    public function item(int $id): Response
+    {
+        $this->checkAdminAccess('extension');
+
+        if (!$request = SubscribeOffer::getOne($id)) {
+            return $this->redirectToRoute('ExtSubscribeOfferList');
+        }
+
+        if (!empty($request->user_agent)) {
+            $request->user_agent = Helper::getUserAgentInfo($request->user_agent);
+        }
+
+        Design::assign('request', $request);
+        Design::assign('extension', $this->getExtension());
+
+        return $this->fetchExtResponse('item.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/SubscribeOffer/Controller/SubscribeOfferListController.php
+++ b/hugashop/crm/Extensions/SubscribeOffer/Controller/SubscribeOfferListController.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\SubscribeOffer\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Secure;
+use HugaShop\Services\Request;
+use App\Services\PaginationService;
+use App\Controller\BaseAdminController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Extensions\SubscribeOffer\Models\SubscribeOffer;
+
+final class SubscribeOfferListController extends BaseAdminController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/SubscribeOffer', name: 'ExtSubscribeOfferList', priority: 20)]
+    public function index(): Response
+    {
+        $this->checkAdminAccess('extension');
+
+        if (Secure::checkCSRF()) {
+            $ids = Request::post('check');
+            if (is_array($ids)) {
+                if (Request::post('action') === 'delete') {
+                    SubscribeOffer::deleteOne($ids);
+                }
+            }
+        }
+
+        $filter         = PaginationService::initFilter();
+        $requests       = SubscribeOffer::getList($filter, order: ['created_at', 'desc']);
+        $requests_count = SubscribeOffer::getCount($filter);
+
+        Design::assign('requests', $requests);
+        Design::assign('pagination', PaginationService::getPagination($requests_count, $filter));
+        Design::assign('extension', $this->getExtension());
+
+        return $this->fetchExtResponse('list.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/SubscribeOffer/Models/SubscribeOffer.php
+++ b/hugashop/crm/Extensions/SubscribeOffer/Models/SubscribeOffer.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\SubscribeOffer\Models;
+
+use HugaShop\Extensions\BaseExtensionModel;
+
+final class SubscribeOffer extends BaseExtensionModel
+{
+    public $timestamps = true;
+
+    protected static $table_fields = [
+        'id'         => ['type' => 'int',     'extra' => 'AUTO_INCREMENT'],
+        'email'      => ['type' => 'varchar', 'req' => true],
+        'page'       => ['type' => 'varchar', 'access' => false],
+        'user_agent' => ['type' => 'varchar', 'access' => false],
+        'ip'         => ['type' => 'varchar', 'access' => false, 'length' => 20],
+    ];
+}

--- a/hugashop/crm/Extensions/SubscribeOffer/TimerGetSubscribeOffer.php
+++ b/hugashop/crm/Extensions/SubscribeOffer/TimerGetSubscribeOffer.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Extensions\SubscribeOffer;
+
+use HugaShop\Models\User\User;
+use HugaShop\Extensions\BaseExtension;
+
+final class SubscribeOffer extends BaseExtension
+{
+    /**
+     * Render scripts on front pages
+     */
+    public static function getFrontBodyTemplate()
+    {
+        if (self::isEnabled() && !User::isLoggedIn()) {
+            return self::fetchTemplate('scripts.tpl');
+        }
+        return;
+    }
+}

--- a/hugashop/crm/Extensions/SubscribeOffer/settings.yaml
+++ b/hugashop/crm/Extensions/SubscribeOffer/settings.yaml
@@ -1,0 +1,11 @@
+name: "Предложение подписки на новости"
+description: "Всплывающее предложение подписаться на новости и получить купон"
+settings_params:
+  - {
+      variable: enabled,
+      name: "Включено",
+      options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }],
+    }
+  - { variable: coupon_code, name: "Код купона", placeholder: "SALE2024" }
+  - { variable: timer, name: "Таймер показа (сек.)", placeholder: "30" }
+version: 1.0

--- a/hugashop/crm/Extensions/SubscribeOffer/templates/form.tpl
+++ b/hugashop/crm/Extensions/SubscribeOffer/templates/form.tpl
@@ -1,0 +1,36 @@
+{block name=subscribe_offer}
+    <div id="subscribe_offer">
+        <div class="mb-4">
+            <h1>Подпишитесь на новости</h1>
+            <p>Введите email и получите купон на скидку</p>
+        </div>
+
+        {if $error=='email_exists'}
+            <div class="alert alert-danger">Такой email уже зарегистрирован</div>
+        {/if}
+
+        <form method="post" action="{'ExtSubscribeOfferForm'|link}" class="needs-validation">
+            {getCSRFInput}
+
+            {if $id}
+                <input type="hidden" name="id" value="{$id}" />
+            {/if}
+
+            <div class="mb-3">
+                <label class="form-label" for="sbo_email">Email</label>
+                <input class="form-control {if $error=='email_exists'}is-invalid{/if}" type="email" name="email" id="sbo_email" value="{$email}" required>
+                <div class="invalid-feedback">Введите email</div>
+            </div>
+
+            <div class="text-end">
+                <button class="btn btn-primary" type="submit">Получить купон</button>
+            </div>
+        </form>
+    </div>
+{/block}
+
+{block name=request_sent}
+    <div id="subscribe_offer_sent">
+        <div class="alert alert-success">Спасибо, ваш купон: <strong>{$coupon}</strong></div>
+    </div>
+{/block}

--- a/hugashop/crm/Extensions/SubscribeOffer/templates/item.tpl
+++ b/hugashop/crm/Extensions/SubscribeOffer/templates/item.tpl
@@ -1,0 +1,61 @@
+{extends 'wrapper/main.tpl'}
+{include 'extension/parts/menu_part.tpl'}
+
+{$meta_title="Подписка #{$request->id}"}
+
+{block name=content }
+    <div class="header_top">
+        <h1>Подписка #{$request->id}</h1>
+    </div>
+    <div class="row gx-5">
+        <div class="col-lg-6">
+            <ul class="property_block">
+                <li>
+                    <div class="col-form-label">Email:</div>
+                    <div class="col-form-label">
+                        <div class="badge text-bg-round copy_field" value="{$request->email}">
+                            {$request->email}
+                            <div class="copy_hover" data-bs-toggle="tooltip" data-bs-original-title="Скопировать">
+                                <i class="material-icons">content_copy</i>
+                            </div>
+                        </div>
+                    </div>
+                </li>
+                <li>
+                    <div class="col-form-label">Страница:</div>
+                    <div class="col-form-label">
+                        <a href="{$request->page}">{$request->page}</a>
+                    </div>
+                </li>
+                <li>
+                    <div class="col-form-label">Дата:</div>
+                    <div class="col-form-label">{$request->created_at|date} {$request->created_at|time}</div>
+                </li>
+                <li>
+                    <div class="col-form-label"></div>
+                    <div class="col-form-label">
+                        <div class="list-group">
+                            <div class="list-group-item">
+                                <div>IP: {$request->ip}</div>
+                                <div>
+                                    <a class="badge text-bg-secondary" href='https://www.ipaddress.com/ipv4/{$request->ip}' target="_blank">где это?</a>
+                                </div>
+                            </div>
+
+                            {if !$request->user_agent|empty}
+                                <div class="list-group-item">
+                                    <div class="col-6">{$request->user_agent->os} {$request->user_agent->os_version}</div>
+                                    <span class="badge text-bg-secondary">{$request->user_agent->device_type}</span>
+                                </div>
+                                <div class="list-group-item">
+                                    <div class="col-6">{$request->user_agent->browser}</div>
+                                    <span class="badge text-bg-secondary">{$request->user_agent->device}</span>
+                                </div>
+                            {/if}
+                        </div>
+                    </div>
+                </li>
+            </ul>
+        </div>
+    </div>
+{/block}

--- a/hugashop/crm/Extensions/SubscribeOffer/templates/list.tpl
+++ b/hugashop/crm/Extensions/SubscribeOffer/templates/list.tpl
@@ -1,0 +1,54 @@
+{extends 'wrapper/main.tpl'}
+{include 'extension/parts/menu_part.tpl'}
+
+{$meta_title='Подписки на новости'}
+
+{block name=content}
+    <div class="header_top">
+        {if $requests_count}
+            <h1>{$requests_count} {$requests_count|plural:'подписка':'подписок':'подписки'}</h1>
+        {else}
+            <h1>Нет подписок</h1>
+        {/if}
+    </div>
+    <div id="main_list">
+        {if $requests->isNotEmpty()}
+            {include file='parts/pagination.tpl'}
+            <form method="post" class="list_form">
+                {getCSRFInput}
+                <div class="list">
+                    {foreach $requests as $r}
+                        <div class="list_row">
+                            <div class="checkbox">
+                                <input class="form-check-input" type="checkbox" name="check[]" value="{$r->id}" />
+                            </div>
+
+                            <div class="col">
+                                <a href="{'ExtSubscribeOfferItem'|link:[id => $r->id]}">{$r->email}</a>
+                                <span class="badge text-bg-round">{$r->created_at|date} {$r->created_at|time}</span>
+                            </div>
+
+                            <div class="icons">
+                                <i class="delete material-icons" data-bs-toggle="tooltip" title="Удалить">cancel</i>
+                            </div>
+                        </div>
+                    {/foreach}
+                </div>
+
+                <div id="action">
+                    <span id='check_all' class='dash_link'>Выбрать все</span>
+                    <span id=select>
+                        <select class="form-select" name="action">
+                            <option value="">Выбрать действие</option>
+                            <option value="delete">Удалить</option>
+                        </select>
+                    </span>
+                    <button class="btn btn-primary apply" id="apply_action" type="submit">Применить</button>
+                </div>
+            </form>
+            {include file='parts/pagination.tpl'}
+        {else}
+            Нет подписок
+        {/if}
+    </div>
+{/block}

--- a/hugashop/crm/Extensions/SubscribeOffer/templates/scripts.tpl
+++ b/hugashop/crm/Extensions/SubscribeOffer/templates/scripts.tpl
@@ -1,0 +1,45 @@
+<script type="module">
+    import { asignFancyAjax } from "{'js/common.js'|asset}";
+
+    let offer_link = "{'ExtSubscribeOfferForm'|link}";
+    let show_timer = {$SubscribeOffer->timer|default:0} * 1000;
+    let storage_key = 'subscribe-offer';
+    let offer_shown = false;
+
+    function openOffer() {
+        if (offer_shown) {
+            return;
+        }
+        offer_shown = true;
+        $.fancybox.open({
+            type: 'ajax',
+            src: offer_link,
+            ajax: {
+                settings: {
+                    method: 'POST',
+                    data: {
+                        page: window.location.href,
+                        csrf: window.csrf
+                    }
+                }
+            },
+            touch: false,
+            closeExisting: true,
+            afterShow: function() {
+                localStorage.setItem(storage_key, new Date().toISOString());
+                asignFancyAjax();
+            }
+        });
+    }
+
+    $(function() {
+        if (localStorage.getItem(storage_key)) {
+            return;
+        }
+        if (show_timer > 0) {
+            setTimeout(openOffer, show_timer);
+        } else {
+            openOffer();
+        }
+    });
+</script>


### PR DESCRIPTION
## Summary
- add SubscribeOffer extension showing modal to subscribe for news and get coupon
- store email subscriptions with admin list and item pages
- prevent registered users and duplicates

## Testing
- `php -l hugashop/crm/Extensions/SubscribeOffer/Controller/SubscribeOfferController.php`
- `php -l hugashop/crm/Extensions/SubscribeOffer/TimerGetSubscribeOffer.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7397ccd008326b876ad50fd4832e1