### PR TITLE
Add Binotel lead management extension

### DIFF
--- a/hugashop/crm/Extensions/Leads/Controller/BinotelController.php
+++ b/hugashop/crm/Extensions/Leads/Controller/BinotelController.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.1
+ *
+ * Webhook controller for Binotel calls.
+ */
+
+namespace HugaShop\Extensions\Leads\Controller;
+
+use App\Controller\BaseFrontController;
+use HugaShop\Extensions\BaseExtensionTrait;
+use HugaShop\Extensions\Leads\Services\BinotelLeadService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class BinotelController extends BaseFrontController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/Leads/binotel/webhook', name: 'ExtLeadsBinotelWebhook', priority: 20)]
+    public function webhook(Request $request): Response
+    {
+        $service = new BinotelLeadService();
+        $service->handleIncomingCall($request->request->all());
+
+        return new Response('ok');
+    }
+}
+

--- a/hugashop/crm/Extensions/Leads/Controller/LeadsListController.php
+++ b/hugashop/crm/Extensions/Leads/Controller/LeadsListController.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ *
+ * Admin controller for listing leads.
+ */
+
+namespace HugaShop\Extensions\Leads\Controller;
+
+use App\Controller\BaseAdminController;
+use App\Services\PaginationService;
+use HugaShop\Extensions\BaseExtensionTrait;
+use HugaShop\Models\Lead;
+use HugaShop\Services\Design;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class LeadsListController extends BaseAdminController
+{
+    use BaseExtensionTrait;
+
+    #[Route('/Leads', name: 'ExtLeadsList', priority: 20)]
+    public function index(): Response
+    {
+        $filter = PaginationService::initFilter();
+
+        $query = Lead::with(['client'])
+            ->withMax(['calls as last_call_at' => 'created_at'])
+            ->orderByDesc('last_call_at');
+
+        if (($limit = $filter['limit']) !== null && $limit !== 'all') {
+            $query->offset(($filter['page'] - 1) * $limit)->limit($limit);
+        }
+
+        $leads = $query->get();
+        $leads_count = Lead::getCount();
+
+        Design::assign('pagination', PaginationService::getPagination($leads_count, $filter));
+        Design::assign('leads', $leads);
+        Design::assign('leads_count', $leads_count);
+        Design::assign('extension', $this->getExtension());
+
+        return $this->fetchExtResponse('leads_list.tpl');
+    }
+}

--- a/hugashop/crm/Extensions/Leads/Leads.php
+++ b/hugashop/crm/Extensions/Leads/Leads.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ *
+ * Extension for collecting telephony leads.
+ */
+
+namespace HugaShop\Extensions\Leads;
+
+use HugaShop\Extensions\BaseExtension;
+
+final class Leads extends BaseExtension
+{
+}
+

--- a/hugashop/crm/Extensions/Leads/Services/BinotelLeadService.php
+++ b/hugashop/crm/Extensions/Leads/Services/BinotelLeadService.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ *
+ * Service for processing Binotel calls and managing leads.
+ */
+
+namespace HugaShop\Extensions\Leads\Services;
+
+use HugaShop\Models\Lead;
+use HugaShop\Models\LeadCall;
+use HugaShop\Models\User\User;
+
+class BinotelLeadService
+{
+    public function handleIncomingCall(array $payload): Lead
+    {
+        $phone = $payload['phone'] ?? null;
+        if (!$phone) {
+            throw new \InvalidArgumentException('Phone number required');
+        }
+
+        $lead = Lead::firstOrCreate(
+            ['phone' => $phone],
+            [
+                'client_id' => $this->findClientId($phone),
+                'status'    => 'new',
+            ]
+        );
+
+        LeadCall::create([
+            'lead_id' => $lead->id,
+            'phone'   => $phone,
+            'type'    => 'incoming',
+            'payload' => json_encode($payload),
+        ]);
+
+        return $lead;
+    }
+
+    private function findClientId(string $phone): int
+    {
+        $client = User::where('phone', $phone)->first();
+        return $client?->id ?? 0;
+    }
+}
+

--- a/hugashop/crm/Extensions/Leads/templates/leads_list.tpl
+++ b/hugashop/crm/Extensions/Leads/templates/leads_list.tpl
@@ -1,0 +1,40 @@
+{extends file='wrapper/main.tpl'}
+{include file='extension/parts/menu_part.tpl'}
+
+{$meta_title='Лиды'}
+
+{block name=content}
+    <div class="header_top">
+        {if $leads_count}
+            <h1>{$leads_count} {$leads_count|plural:'лид':'лидов':'лида'}</h1>
+        {else}
+            <h1>Нет лидов</h1>
+        {/if}
+    </div>
+
+    <div id="main_list">
+        {if $leads->isNotEmpty()}
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Телефон</th>
+                        <th>Клиент</th>
+                        <th>Последний звонок</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {foreach $leads as $lead}
+                        <tr>
+                            <td>{$lead->phone}</td>
+                            <td>{if $lead->client}{$lead->client->name}{/if}</td>
+                            <td>{if $lead->last_call_at}{$lead->last_call_at|date_format:'%d.%m.%Y %H:%M'}{/if}</td>
+                        </tr>
+                    {/foreach}
+                </tbody>
+            </table>
+            {include file='parts/pagination.tpl'}
+        {else}
+            Нет лидов
+        {/if}
+    </div>
+{/block}

--- a/hugashop/crm/Models/Lead.php
+++ b/hugashop/crm/Models/Lead.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.1
+ *
+ * Lead entity produced from incoming calls.
+ */
+
+namespace HugaShop\Models;
+
+use HugaShop\Models\LeadCall;
+use HugaShop\Models\User\User;
+
+class Lead extends BaseModel
+{
+    public $timestamps = true;
+
+    protected static $table_fields = [
+        'id' =>         ['type' => 'int',     'extra' => 'AUTO_INCREMENT'],
+        'client_id' =>  ['type' => 'int',     'def' => 0],
+        'phone' =>      ['type' => 'varchar', 'length' => 32, 'search' => true],
+        'status' =>     ['type' => 'varchar', 'length' => 32, 'def' => 'new'],
+    ];
+
+    public function client()
+    {
+        return $this->belongsTo(User::class, 'client_id', 'id');
+    }
+
+    public function calls()
+    {
+        return $this->hasMany(LeadCall::class, 'lead_id', 'id');
+    }
+}
+

--- a/hugashop/crm/Models/LeadCall.php
+++ b/hugashop/crm/Models/LeadCall.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ *
+ * Call history for leads.
+ */
+
+namespace HugaShop\Models;
+
+class LeadCall extends BaseModel
+{
+    public $timestamps = true;
+
+    protected static $table_fields = [
+        'id' =>      ['type' => 'int',     'extra' => 'AUTO_INCREMENT'],
+        'lead_id' => ['type' => 'int'],
+        'phone' =>  ['type' => 'varchar', 'length' => 32],
+        'type' =>   ['type' => 'varchar', 'length' => 16],
+        'payload' =>['type' => 'text'],
+    ];
+}
+


### PR DESCRIPTION
## Summary
- expose Binotel webhook controller using BaseFrontController route
- provide admin leads list with phone, client name and last call timestamp
- track client and call relations in Lead model

## Testing
- `php -l hugashop/crm/Extensions/Leads/Controller/BinotelController.php`
- `php -l hugashop/crm/Extensions/Leads/Controller/LeadsListController.php`
- `php -l hugashop/crm/Models/Lead.php`
- `php -l hugashop/crm/Extensions/Leads/Services/BinotelLeadService.php`
- `php -l hugashop/crm/Extensions/Leads/Leads.php`
- `composer validate`

------
https://chatgpt.com/codex/tasks/task_e_68a7e123e24c8326ba599aed38945c28