### PR TITLE
feat: add error popover for database check

### DIFF
--- a/hugashop/crm/Addons/DatabaseCheck/Controller/DatabaseCheckController.php
+++ b/hugashop/crm/Addons/DatabaseCheck/Controller/DatabaseCheckController.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.2
+ * @version 1.3
  *
  */
 
@@ -38,10 +38,11 @@ final class DatabaseCheckController extends BaseAdminController
     {
         $this->checkAdminAccess('addon', true);
 
-        $class = Request::post('model', 'string');
-        $status = 'ok';
-        $rows = 0;
-        $size = 0;
+        $class   = Request::post('model', 'string');
+        $status  = 'ok';
+        $message = '';
+        $rows    = 0;
+        $size    = 0;
 
         try {
 
@@ -52,14 +53,17 @@ final class DatabaseCheckController extends BaseAdminController
             $schema = DB::schema();
 
             if (!$schema->hasTable($table)) {
-                $status = 'error';
+                $status  = 'error';
+                $message = 'Таблица не найдена';
             } else {
 
                 // check columns exist
                 $columns = $schema->getColumnListing($table);
-                $fields = array_keys($class::getFields());
-                if (!empty(array_diff($fields, $columns))) {
-                    $status = 'error';
+                $fields  = array_keys($class::getFields());
+                $missing = array_diff($fields, $columns);
+                if (!empty($missing)) {
+                    $status  = 'error';
+                    $message = 'Отсутствуют поля: ' . implode(', ', $missing);
                 }
 
                 $rows = DB::table($table)->count();
@@ -79,12 +83,14 @@ final class DatabaseCheckController extends BaseAdminController
                 $size = (int)($info->size ?? 0);
             }
         } catch (\Throwable $e) {
-            $status = 'error';
+            $status  = 'error';
+            $message = $e->getMessage();
         }
 
         return $this->json([
             'model' => class_basename($class),
             'status' => $status,
+            'message' => $message,
             'rows'   => $rows,
             'size'   => Helper::convertBytes($size),
         ]);

--- a/hugashop/crm/Addons/DatabaseCheck/templates/index.tpl
+++ b/hugashop/crm/Addons/DatabaseCheck/templates/index.tpl
@@ -1,4 +1,4 @@
-{* @version 0.1 *}
+{* @version 0.2 *}
 {extends 'wrapper/main.tpl'}
 {include 'addon/parts/menu_part.tpl'}
 
@@ -46,8 +46,6 @@
                 const rows = $('tbody tr');
                 const models = rows.map((_, r) => $(r).data('model')).get();
                 const button = $('#check_tables');
-                const info =
-                    '<i class="delete material-icons" title="информация" data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-content="And heres some amazing content.">info_outline</i>';
 
                 let index = 0;
 
@@ -65,9 +63,21 @@
                     }, function(data) {
                         const row = $('tr[data-model="' + CSS.escape(model) + '"]');
                         if (row.length) {
-                            row.find('.status').text(data.status);
                             row.find('.rows').text(data.rows);
                             row.find('.size').text(data.size);
+                            if (data.status === 'ok') {
+                                row.find('.status').text('ok');
+                            } else {
+                                const icon = $('<i/>', {
+                                    class: 'material-icons text-danger',
+                                    text: 'info_outline',
+                                    'data-bs-toggle': 'popover',
+                                    'data-bs-trigger': 'hover focus',
+                                    'data-bs-content': data.message
+                                });
+                                row.find('.status').empty().append(icon);
+                                bootstrap.Popover.getOrCreateInstance(icon[0]);
+                            }
                         }
 
                         index++;


### PR DESCRIPTION
## Summary
- show database table check errors via popover in admin addon
- send error message from DatabaseCheckController

## Testing
- `php -l hugashop/crm/Addons/DatabaseCheck/Controller/DatabaseCheckController.php`
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_e_68a8ffc00c60832691c6dbb65ed0925b