### PR TITLE
feat: add admin banner list for CarouselPromo

### DIFF
--- a/hugashop/crm/Addons/CarouselPromo/Controller/CarouselPromoController.php
+++ b/hugashop/crm/Addons/CarouselPromo/Controller/CarouselPromoController.php
@@ -4,17 +4,22 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.9
+ * @version 2.2
  *
  */
 
 namespace HugaShop\Addons\CarouselPromo\Controller;
 
 use HugaShop\Services\Design;
+use HugaShop\Services\Helper;
 use HugaShop\Services\Secure;
+use HugaShop\Services\Request;
+use App\Services\ImageService;
 use App\Controller\BaseAdminController;
 use HugaShop\Addons\BaseAddonTrait;
 use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Addons\CarouselPromo\Models\CarouselPromoBanner;
+use HugaShop\Addons\CarouselPromo\CarouselPromo;
 
 final class CarouselPromoController extends BaseAdminController
 {
@@ -30,11 +35,69 @@ final class CarouselPromoController extends BaseAdminController
 
         // Обработка действий
         if (Secure::checkCSRF()) {
-            //...
+
+            // Действия с выбранными
+            $ids = Request::post('check');
+            if (is_array($ids)) {
+                switch (Request::post('action')) {
+                    case 'disable':
+                        CarouselPromoBanner::updateList($ids, ['enabled' => 0]);
+                        break;
+                    case 'enable':
+                        CarouselPromoBanner::updateList($ids, ['enabled' => 1]);
+                        break;
+                    case 'delete':
+                        foreach ($ids as $id) {
+                            CarouselPromoBanner::deleteOne($id);
+                        }
+                        break;
+                }
+            }
+
+            foreach (Helper::getPositions() as $id => $position) {
+                CarouselPromoBanner::updateOne($id, ['position' => $position]);
+            }
         }
 
+        Design::assign('banners', CarouselPromoBanner::getList(order: 'position', join: ['image']));
         Design::assign('addon', $this->getAddon());
 
         return $this->fetchAddonResponse('index.tpl');
+    }
+
+    /**
+     * Добавление/редактирование баннера
+     */
+    #[Route('/CarouselPromo/banner', name: 'AddonCarouselPromoBannerNew', priority: 20)]
+    #[Route('/CarouselPromo/banner/{id}', name: 'AddonCarouselPromoBanner', priority: 20)]
+    public function banner(?int $id = null)
+    {
+        #### Update
+        ###########
+        if (!empty($banner = Secure::getInputCheckEditAccess(CarouselPromoBanner::class, $id))) {
+            if (empty($banner->id)) {
+                $banner = Design::setFlashMessage('add', CarouselPromoBanner::createOne($banner));
+            } else {
+                Design::setFlashMessage('update', CarouselPromoBanner::updateOne($banner->id, $banner));
+            }
+
+            ImageService::catchImages($banner->id, CarouselPromo::class);
+
+            return $this->redirectToRouteLang('AddonCarouselPromoBanner', ['id' => $banner->id]);
+        }
+
+        #### View
+        #########
+        if (!empty($id)) {
+            $banner = CarouselPromoBanner::getOne($id, join: ['images']);
+            if (empty($banner->id)) {
+                return $this->redirectToRoute('AddonCarouselPromo');
+            }
+        }
+
+        Design::assign('banner', $banner);
+        Design::assign('addon', $this->getAddon());
+
+        return $this->fetchAddonResponse('banner.tpl');
     }
 }

--- a/hugashop/crm/Addons/CarouselPromo/Models/CarouselPromoBanner.php
+++ b/hugashop/crm/Addons/CarouselPromo/Models/CarouselPromoBanner.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.1
+ *
+ */
+
+namespace HugaShop\Addons\CarouselPromo\Models;
+
+use HugaShop\Models\Image;
+use HugaShop\Addons\CarouselPromo\CarouselPromo;
+use HugaShop\Addons\BaseAddonModel;
+
+final class CarouselPromoBanner extends BaseAddonModel
+{
+    protected static $table_fields = [
+        'id'       => ['type' => 'int',     'extra' => 'AUTO_INCREMENT'],
+        'name'     => ['type' => 'varchar', 'required' => 'true'],
+        'url'      => ['type' => 'varchar'],
+        'position' => ['type' => 'int',     'def' => 0],
+        'enabled'  => ['type' => 'tinyint', 'def' => 0],
+    ];
+
+    public function image()
+    {
+        return $this->hasOne(Image::class, 'entity_id')
+            ->where('entity_name', CarouselPromo::class)
+            ->where('visible', 1)
+            ->orderBy('position');
+    }
+
+    public function images()
+    {
+        return $this->hasMany(Image::class, 'entity_id')
+            ->where('entity_name', CarouselPromo::class)
+            ->orderBy('position');
+    }
+}

--- a/hugashop/crm/Addons/CarouselPromo/templates/banner.tpl
+++ b/hugashop/crm/Addons/CarouselPromo/templates/banner.tpl
@@ -1,0 +1,59 @@
+{extends 'wrapper/main.tpl'}
+{include 'addon/parts/menu_part.tpl'}
+
+{if $banner->id}
+        {$meta_title = $banner->name}
+{else}
+        {$meta_title = 'Новый баннер'}
+{/if}
+
+{block name=content}
+
+        <!-- Основная форма -->
+        <form method="post" enctype="multipart/form-data">
+                <input name="id" type="hidden" value="{$banner->id}" />
+                {getCSRFInput}
+
+                <div class="row gx-5">
+
+                        <div class="col-12">
+                                <div class="over_name">
+                                        <div class="checkbox_line">
+                                                <div class="form-check form-switch">
+                                                        <input type="hidden" name="enabled" value="0">
+                                                        <input class="form-check-input" name="enabled" value="1" type="checkbox" role="switch"
+                                                                id="enabled" {if $banner->enabled}checked{/if} />
+                                                        <label class="form-check-label" for="enabled">Активен</label>
+                                                </div>
+                                        </div>
+                                </div>
+
+                                <div class="name_row">
+                                        <span class="col-form-label item_id">#{$banner->id}</span>
+                                        <input class="form-control form-control-lg" name="name" type="text" value="{$banner->name}" placeholder="Название баннера" />
+                                </div>
+                        </div>
+
+                        <div class="col-12 layer">
+                                <h2>Свойства</h2>
+                                <ul class="property_block">
+                                        <li>
+                                                <label for="url" class="col-form-label">Ссылка</label>
+                                                <input class="form-control" id="url" name="url" type="text" value="{$banner->url}" />
+                                        </li>
+                                </ul>
+                        </div>
+
+                        <div class="col-12 layer">
+                                <h2>Изображение</h2>
+                                {include file='parts\\image_upload_part.tpl' images=$banner->images can_edit=true}
+                        </div>
+
+                        <div class="col-12 btn_row">
+                                {include file="parts/button.tpl"}
+                        </div>
+
+                </div>
+        </form>
+{/block}
+

--- a/hugashop/crm/Addons/CarouselPromo/templates/index.tpl
+++ b/hugashop/crm/Addons/CarouselPromo/templates/index.tpl
@@ -1,22 +1,90 @@
-{extends file='wrapper/main.tpl'}
-{include file='addon/parts/menu_part.tpl'}
+{extends 'wrapper/main.tpl'}
+{include 'addon/parts/menu_part.tpl'}
 
 {$meta_title='Карусель'}
 
 {block name=content}
 
-    <!-- Заголовок -->
-    <div class="header_top">
-        <h1 class="total_amount">{$meta_title}</h1>
-    </div>
-
-    <!-- Основная форма -->
-    <form method="post" enctype="multipart/form-data">
-        {getCSRFInput}
-
-        <div class="row gx-5">
-
+        <!-- Заголовок -->
+        <div class="header_top">
+                <h1>{$meta_title}</h1>
+                <a class="add" href="{'AddonCarouselPromoBannerNew'|link}">Добавить баннер</a>
         </div>
-    </form>
 
+        <div id="main_list">
+
+                {if $banners}
+                        <form method="post" class="list_form">
+                                {getCSRFInput}
+
+                                <div class="list sortable_on">
+                                        {foreach $banners as $banner}
+                                                <div class="{if !$banner->enabled}enabled_off{/if} list_row">
+
+                                                        <div class="move">
+                                                                <div class="move_zone"></div>
+                                                                <input type="hidden" name="positions[{$banner->id}]" value="{$banner->position}">
+                                                        </div>
+
+                                                        <div class="checkbox">
+                                                                <input class="form-check-input" type="checkbox" name="check[]" value="{$banner->id}" />
+                                                        </div>
+
+                                                        <div class="row col">
+                                                                <div class="col-12 col-sm-8">
+                                                                        <a href="{'AddonCarouselPromoBanner'|link:[id => $banner->id]}">
+                                                                                <img src="{if $banner->image->filename}{$banner->image->filename|resize:120:120:c}{/if}" alt="{$banner->name}" class="img-fluid me-2" style="max-width:120px;"/>
+                                                                                <span>{$banner->name}</span>
+                                                                        </a>
+                                                                </div>
+                                                                <div class="col-12 col-sm-4 text-end">
+                                                                        <span class="badge text-bg-round">{$banner->id}</span>
+                                                                </div>
+                                                        </div>
+
+                                                        <div class="icons">
+                                                                <i class="enable material-icons visibility" data-bs-toggle="tooltip" title="Активна"></i>
+                                                                <i class="delete material-icons" data-bs-toggle="tooltip" title="Удалить">cancel</i>
+                                                        </div>
+                                                </div>
+                                        {/foreach}
+                                </div>
+
+                                <div id="action">
+                                        <span id="check_all" class="dash_link">Выбрать все</span>
+                                        <span id="select">
+                                                <select class="form-select" name="action">
+                                                        <option value="">Выбрать действие</option>
+                                                        <option value="enable">Сделать видимыми</option>
+                                                        <option value="disable">Сделать невидимыми</option>
+                                                        <option value="delete">Удалить</option>
+                                                </select>
+                                        </span>
+                                        {include file="parts/button.tpl" label="Применить" extra_attrs='id=apply_action'}
+                                </div>
+                        </form>
+
+                {else}
+                        Нет баннеров
+                {/if}
+        </div>
+{/block}
+
+
+{block name=body_script append}
+        <script type="module">
+                import { ajax_icon } from '{"js/common.js"|asset}';
+
+                {literal}
+                        $(function() {
+
+                                // Показать
+                                $("i.enable").click(function() {
+                                        ajax_icon($(this), 'CarouselPromoBanner', 'enabled', csrf);
+                                        return false;
+                                });
+
+                        });
+                {/literal}
+        </script>
 {/block}


### PR DESCRIPTION
## Summary
- handle banner images via standard ImageService for CarouselPromo::class
- expose banner image relations and render upload widget on banner form
- show first banner image in admin list

## Testing
- `php -l hugashop/crm/Addons/CarouselPromo/Controller/CarouselPromoController.php`
- `php -l hugashop/crm/Addons/CarouselPromo/Models/CarouselPromoBanner.php`
- `composer test` *(fails: Command "test" is not defined)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2b7953308326ab3034c80fb6871d