### PR TITLE
Handle CarouselPromo banner deletions

### DIFF
--- a/hugashop/crm/Addons/CarouselPromo/CarouselPromo.php
+++ b/hugashop/crm/Addons/CarouselPromo/CarouselPromo.php
@@ -4,13 +4,15 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.7
+ * @version 1.8
  *
  */
 
 namespace HugaShop\Addons\CarouselPromo;
 
 use HugaShop\Addons\BaseAddon;
+use HugaShop\Services\Design;
+use HugaShop\Addons\CarouselPromo\Models\CarouselPromoBanner;
 
 final class CarouselPromo extends BaseAddon
 {
@@ -20,6 +22,9 @@ final class CarouselPromo extends BaseAddon
      */
     public static function getTemplate(array $params = [])
     {
+        Design::assign('banners', CarouselPromoBanner::getList(filter: ['enabled' => 1], order: 'position', join: ['image']));
+        Design::assign('addon', self::getAddon());
+
         return self::fetchTemplate('carousel.tpl');
     }
 }

--- a/hugashop/crm/Addons/CarouselPromo/Models/CarouselPromoBanner.php
+++ b/hugashop/crm/Addons/CarouselPromo/Models/CarouselPromoBanner.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.1
+ * @version 1.2
  *
  */
 
@@ -39,5 +39,19 @@ final class CarouselPromoBanner extends BaseAddonModel
         return $this->hasMany(Image::class, 'entity_id')
             ->where('entity_name', CarouselPromo::class)
             ->orderBy('position');
+    }
+
+    public static function deleteOne(array|int $ids)
+    {
+        $ids_array = is_array($ids) ? $ids : [$ids];
+
+        foreach ($ids_array as $id) {
+            Image::where('entity_name', CarouselPromo::class)
+                ->where('entity_id', $id)
+                ->get()
+                ->each(fn($image) => Image::deleteImage($image->id));
+        }
+
+        return parent::deleteOne($ids);
     }
 }


### PR DESCRIPTION
## Summary
- Pass enabled CarouselPromo banners and addon settings to the carousel template
- Remove banner images when deleting banners

## Testing
- `php -l hugashop/crm/Addons/CarouselPromo/CarouselPromo.php`
- `php -l hugashop/crm/Addons/CarouselPromo/Models/CarouselPromoBanner.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab8362858c8326a12749c432ee30d8