### PR TITLE
feat: render promo carousel banners with owl

### DIFF
--- a/hugashop/crm/Addons/CarouselPromo/templates/carousel.tpl
+++ b/hugashop/crm/Addons/CarouselPromo/templates/carousel.tpl
@@ -1,23 +1,25 @@
-<div id="carouselPromo" class="carousel slide" data-bs-ride="carousel">
-
-    <div class="carousel-inner">
-        <div class="carousel-item active" data-bs-interval="300">
-            <img src="..." class="d-block w-100" alt="...">
-        </div>
-        <div class="carousel-item">
-            <img src="..." class="d-block w-100" alt="...">
-        </div>
-        <div class="carousel-item">
-            <img src="..." class="d-block w-100" alt="...">
-        </div>
+{if $banners}
+<div id='carouselPromo'>
+    <div class='owl-carousel'>
+        {foreach $banners as $banner}
+            {if $banner->image->filename}
+                <div class='item'>
+                    {if $banner->link}<a href='{$banner->link}'>{/if}
+                        <img src='{$banner->image->filename|resize:1920:600}' alt='{$banner->name}' class='img-fluid w-100' />
+                    {if $banner->link}</a>{/if}
+                </div>
+            {/if}
+        {/foreach}
     </div>
-
-    <button class="carousel-control-prev" type="button" data-bs-target="#carouselPromo" data-bs-slide="prev">
-        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-        <span class="visually-hidden">Previous</span>
-    </button>
-    <button class="carousel-control-next" type="button" data-bs-target="#carouselPromo" data-bs-slide="next">
-        <span class="carousel-control-next-icon" aria-hidden="true"></span>
-        <span class="visually-hidden">Next</span>
-    </button>
 </div>
+
+<script type='module'>
+    import '{"js/owlcarousel/owl.carousel.min.js"|asset}';
+    import { owlCarouselInit } from '{"js/common.js"|asset}';
+
+    document.addEventListener('DOMContentLoaded', function () {
+        owlCarouselInit(document.getElementById('carouselPromo'));
+    });
+</script>
+{/if}
+


### PR DESCRIPTION
## Summary
- render enabled promo banners in OwlCarousel
- initialize carousel on DOM ready via owlCarouselInit

## Testing
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ab90e2b6648326979c6355edcad6da