### PR TITLE
feat: replace owl carousel with tiny slider

### DIFF
--- a/hugashop/crm/Addons/CarouselPromo/templates/carousel.tpl
+++ b/hugashop/crm/Addons/CarouselPromo/templates/carousel.tpl
@@ -1,6 +1,6 @@
 {if $banners}
     <div id='carouselPromo'>
-        <div class='owl-carousel'>
+        <div class='tiny-slider'>
             {foreach $banners as $banner}
                 {if $banner->image->filename}
                     <div class='item'>
@@ -12,22 +12,35 @@
             {/foreach}
         </div>
 
-        <button class="carousel-control-prev" type="button" data-bs-target="#carouselPromo" data-bs-slide="prev">
+        <button class="carousel-control-prev" type="button">
             <span class="carousel-control-prev-icon" aria-hidden="true"></span>
             <span class="visually-hidden">Previous</span>
         </button>
-        <button class="carousel-control-next" type="button" data-bs-target="#carouselPromo" data-bs-slide="next">
+        <button class="carousel-control-next" type="button">
             <span class="carousel-control-next-icon" aria-hidden="true"></span>
             <span class="visually-hidden">Next</span>
         </button>
     </div>
 
     <script type='module'>
-        import '{"js/owlcarousel/owl.carousel.min.js"|asset}';
-        import { owlCarouselInit } from '{"js/common.js"|asset}';
+        import '{"js/tiny-slider/tiny-slider.js"|asset}';
+        import '{"js/common.js"|asset}';
 
         $(function() {
-            owlCarouselInit($('#carouselPromo'));
+            tns({
+                container: '#carouselPromo .tiny-slider',
+                items: 2,
+                gutter: 0,
+                loop: true,
+                nav: false,
+                controls: true,
+                prevButton: document.querySelector('#carouselPromo .carousel-control-prev'),
+                nextButton: document.querySelector('#carouselPromo .carousel-control-next'),
+                responsive: {
+                    760: { items: 3 },
+                    1000: { items: 4 }
+                }
+            });
         });
     </script>
 {/if}


### PR DESCRIPTION
## Summary
- replace Owl Carousel usage with tiny-slider in CarouselPromo template

## Testing
- `composer test` *(fails: Command "test" is not defined.)*


------
https://chatgpt.com/codex/tasks/task_e_68aba8a6c8b083268ac9fd5d6ce58be4