### PR TITLE
feat: limit admin image upload count

### DIFF
--- a/templates/admin/assets/js/image.js
+++ b/templates/admin/assets/js/image.js
@@ -3,7 +3,7 @@
  * Handles image sorting, visibility and uploading
  *
  * @author Andri Huga
- * @version 1.4
+ * @version 1.5
  */
 
 export function initImagesUpload() {
@@ -13,8 +13,17 @@ export function initImagesUpload() {
         opacity: 0.90
     });
 
+    $(".images").each(function () {
+        const container = $(this);
+        const maxImages = parseInt(container.data('max-images')) || 0;
+        if (maxImages && container.find('ul li').length >= maxImages) {
+            container.find('.dropZone').hide();
+        }
+    });
+
     $(".images").on('click.delete', ' i.delete', function () {
-        $(this).closest(".images").find("input[name='delete_image']").val('1');
+        const imagesBlock = $(this).closest(".images");
+        imagesBlock.find("input[name='delete_image']").val('1');
         $(this).closest("li").fadeOut(200, function () {
             document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
                 const tooltip = bootstrap.Tooltip.getInstance(el);
@@ -23,7 +32,10 @@ export function initImagesUpload() {
                 }
             });
             $(this).remove();
-
+            const maxImages = parseInt(imagesBlock.data('max-images')) || 0;
+            if (maxImages && imagesBlock.find('ul li').length < maxImages) {
+                imagesBlock.find('.dropZone').show();
+            }
         });
         return false;
     });
@@ -67,11 +79,18 @@ export function initImagesUpload() {
 
         let files = evt.target.files;
         let dropInput = $(evt.target);
-        let name = dropInput.closest('.images').attr('id');
+        let container = dropInput.closest('.images');
+        let name = container.attr('id');
+        let maxImages = parseInt(container.data('max-images')) || 0;
+        let currentCount = container.find('ul li').length;
 
         for (let i = 0, file; file = files[i]; i++) {
             if (!file.type.match('image.*')) {
                 continue;
+            }
+
+            if (maxImages && currentCount >= maxImages) {
+                break;
             }
 
             let reader = new FileReader();
@@ -93,6 +112,11 @@ export function initImagesUpload() {
             })(file);
 
             reader.readAsDataURL(file);
+            currentCount++;
+        }
+
+        if (maxImages && currentCount >= maxImages) {
+            container.find('.dropZone').hide();
         }
 
         // Add new empty input for next selection

--- a/templates/admin/html/parts/image_upload_part.tpl
+++ b/templates/admin/html/parts/image_upload_part.tpl
@@ -1,4 +1,5 @@
-<div id="images" class="images">
+{assign var="max_images" value=$max_images|default:0}
+<div id="images" class="images" {if $max_images}data-max-images="{$max_images}"{/if}>
     <ul class="image_list">
         {foreach $images as $image}
             {if !$image|empty}
@@ -21,10 +22,12 @@
         {/foreach}
     </ul>
 
+    {if !$max_images || $images|count < $max_images}
     <div class="dropZone">
-        <input type="file" name="dropped_images[]" multiple class="dropInput" />
-        <div class="dropMessage">Перетащите файлы сюда</div>
+        <input type="file" name="dropped_images[]" {if !$max_images || $max_images > 1}multiple{/if} class="dropInput" />
+        <div class="dropMessage">Перетащите файлы сюда{if $max_images} (максимум {$max_images}){/if}</div>
     </div>
+    {/if}
 
     {if $can_edit}
         <div class="col-12 btn_row">


### PR DESCRIPTION
## Summary
- allow configuring maximum uploaded images for admin image picker
- enforce image limit client-side and hide uploader when reached

## Testing
- `composer test` *(fails: Command "test" is not defined.)*

------
https://chatgpt.com/codex/tasks/task_e_68acc47d4c848326b88fba7759f7d1fc