### PR TITLE
Add live character counters to product textareas

### DIFF
--- a/templates/admin/html/product/product.tpl
+++ b/templates/admin/html/product/product.tpl
@@ -196,7 +196,18 @@
 		let product_id = "{$product->id}";
 
 		{literal}
-			$(function() {
+						$(function() {
+
+				$('.world_count').each(function() {
+					const textarea = $(this);
+					const counter = $('<div class="text-end small text-muted"></div>');
+					textarea.after(counter);
+					const update_count = function() {
+						counter.text(textarea.val().length);
+					};
+					textarea.on('input', update_count);
+					update_count();
+				});
 
 				// Useful select
 				$(".chosen_select").chosen();


### PR DESCRIPTION
## Summary
- show live character counts under product meta description and annotation textareas using jQuery

## Testing
- `composer validate`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68af7b3f9a3c8326bb9f0d2494339217