### PR TITLE
Add OpenAI admin request playground

### DIFF
--- a/hugashop/crm/Addons/OpenAI/Controller/RequestController.php
+++ b/hugashop/crm/Addons/OpenAI/Controller/RequestController.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ *
+ * OpenAI custom request playground
+ */
+
+namespace HugaShop\Addons\OpenAI\Controller;
+
+use OpenAI;
+use HugaShop\Services\Secure;
+use HugaShop\Services\Request;
+use App\Controller\BaseAdminController;
+use HugaShop\Addons\BaseAddonTrait;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+final class RequestController extends BaseAdminController
+{
+    use BaseAddonTrait;
+
+    /**
+     * Show request playground page
+     */
+    #[Route('/OpenAI', name: 'AddonOpenAI', priority: 20)]
+    public function index()
+    {
+        return $this->fetchAddonResponse('request.tpl');
+    }
+
+    /**
+     * Send custom request to OpenAI
+     */
+    #[Route('/OpenAI/ajax/request', name: 'AddonOpenAIRequest', priority: 20)]
+    public function request()
+    {
+        if (!Secure::checkCSRF()) {
+            return new JsonResponse(['error' => 'csrf']);
+        }
+
+        $system_content = Request::post('system_content', 'string');
+        $user_content   = Request::post('user_content', 'string');
+
+        if (empty($system_content) || empty($user_content)) {
+            return new JsonResponse(['error' => 'params']);
+        }
+
+        $key = self::getSettings()->api_key;
+        if (empty($key)) {
+            return new JsonResponse(['error' => 'openai_key']);
+        }
+
+        $client = OpenAI::client($key);
+        $result = $client->chat()->create([
+            'model' => 'gpt-4o',
+            'messages' => [
+                ['role' => 'system', 'content' => $system_content],
+                ['role' => 'user', 'content' => $user_content],
+            ],
+        ]);
+
+        return new JsonResponse([
+            'content' => trim($result->choices[0]->message->content),
+        ]);
+    }
+}

--- a/hugashop/crm/Addons/OpenAI/settings.yaml
+++ b/hugashop/crm/Addons/OpenAI/settings.yaml
@@ -2,4 +2,4 @@ name: "OpenAI"
 description: "Интеграция с OpenAI"
 settings_params:
   - { variable: api_key, name: "Api key" }
-version: 1.0
+version: 1.1

--- a/hugashop/crm/Addons/OpenAI/templates/request.tpl
+++ b/hugashop/crm/Addons/OpenAI/templates/request.tpl
@@ -1,0 +1,48 @@
+{include 'addon/parts/menu_part.tpl'}
+
+{$meta_title='OpenAI'}
+
+{block name=content}
+    <div class="header_top">
+        <h1>Запрос в OpenAI</h1>
+    </div>
+
+    <form id="openai_form" method="post">
+        {getCSRFInput}
+        <div class="mb-3">
+            <label class="form-label" for="system_content">System content</label>
+            <textarea class="form-control" name="system_content" id="system_content" rows="5"></textarea>
+        </div>
+        <div class="mb-3">
+            <label class="form-label" for="user_content">User content</label>
+            <textarea class="form-control" name="user_content" id="user_content" rows="5"></textarea>
+        </div>
+        <div class="mb-3">
+            <button type="submit" class="btn btn-primary">Отправить</button>
+        </div>
+    </form>
+
+    <div id="openai_result" class="mt-3"></div>
+
+    <script type="module">
+        {literal}
+        $(function() {
+            $('#openai_form').on('submit', function(e) {
+                e.preventDefault();
+                $.ajax({
+                    url: "{'AddonOpenAIRequest'|link}",
+                    type: 'POST',
+                    data: $('#openai_form').serialize(),
+                    success: function(resp) {
+                        if (resp.content) {
+                            $('#openai_result').html('<pre>' + resp.content + '</pre>');
+                        } else if (resp.error) {
+                            $('#openai_result').html('<div class="text-danger">' + resp.error + '</div>');
+                        }
+                    }
+                });
+            });
+        });
+        {/literal}
+    </script>
+{/block}


### PR DESCRIPTION
## Summary
- add admin page for sending custom requests to OpenAI
- support system and user content with AJAX result preview
- bump OpenAI addon version

## Testing
- `php -l hugashop/crm/Addons/OpenAI/Controller/RequestController.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68b07fc56b2883269d566547ff20f8b5