### PR TITLE
feat: fetch keywords from Yandex Wordstat

### DIFF
--- a/hugashop/crm/Addons/YandexWordstat/Services/YandexWordstatService.php
+++ b/hugashop/crm/Addons/YandexWordstat/Services/YandexWordstatService.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.1
+ * @version 1.2
  * 
  * @link https://yandex.com/support2/wordstat/ru/content/api-wordstat
  * @link https://yandex.com/support2/wordstat/ru/content/api-structure
@@ -21,19 +21,57 @@ class YandexWordstatService
     use BaseAddonTrait;
 
     /**
-     * Create base chat
+     * Получаем ключевые слова из Yandex Wordstat
+     *
+     * @param string $keyword
+     * @param string $language
+     * @param int $region
+     * @return array|null
      */
     public static function getKewords($keyword, $language = 'ru', $region = 225)
     {
         $auth_token = self::getSettings()?->auth_token;
-        $client_id = self::getSettings()?->client_id;
+        $client_id  = self::getSettings()?->client_id;
 
         if (empty($auth_token) || empty($client_id)) {
             return null;
         }
 
+        $params = [
+            'method' => 'Get',
+            'params' => [
+                'SelectionCriteria' => [
+                    'Keywords' => [$keyword],
+                    'GeoId'    => [$region],
+                    'Language' => $language,
+                ],
+                'FieldNames' => [
+                    'Keyword',
+                    'Shows',
+                ],
+            ],
+        ];
 
-        $result = '';
-        return $result;
+        $client = new \GuzzleHttp\Client([
+            'base_uri' => 'https://api.direct.yandex.com/json/v5/',
+        ]);
+
+        try {
+            $response = $client->request('POST', 'keywordsstat', [
+                'headers' => [
+                    'Authorization'    => 'Bearer ' . $auth_token,
+                    'Client-Login'     => $client_id,
+                    'Accept-Language'  => $language,
+                    'Content-Type'     => 'application/json; charset=utf-8',
+                ],
+                'json' => $params,
+            ]);
+
+            $data = json_decode($response->getBody()->getContents(), true);
+
+            return $data['result']['KeywordsStatItems'] ?? [];
+        } catch (\Throwable $e) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- query Yandex Wordstat API to retrieve keyword statistics

## Testing
- `php -l HugaShop/hugashop/crm/Addons/YandexWordstat/Services/YandexWordstatService.php`
- `composer validate --no-check-lock`

------
https://chatgpt.com/codex/tasks/task_e_68b09efe05f0832687fb4e8cf8cdaf9d