### PR TITLE
Reset OpenAI request button after response

### DIFF
--- a/hugashop/crm/Addons/OpenAI/templates/request.tpl
+++ b/hugashop/crm/Addons/OpenAI/templates/request.tpl
@@ -33,16 +33,23 @@
             $(function() {
                 $('#openai_form').on('submit', function(e) {
                     e.preventDefault();
+                    const $form = $(this);
+                    const $submit_btn = $form.find('button[type="submit"]');
                     $.ajax({
                         url: open_ai_url,
                         type: 'POST',
-                        data: $('#openai_form').serialize(),
+                        data: $form.serialize(),
+                        beforeSend: function() {
+                            $submit_btn.prop('disabled', true).addClass('disabled');
+                        },
+                        complete: function() {
+                            $submit_btn.prop('disabled', false).removeClass('disabled');
+                        },
                         success: function(resp) {
                             if (resp.content) {
                                 $('#openai_result').html('<pre>' + resp.content + '</pre>');
                             } else if (resp.error) {
-                                $('#openai_result').html('<div class="text-danger">' + resp.error +
-                                    '</div>');
+                                $('#openai_result').html('<div class="text-danger">' + resp.error + '</div>');
                             }
                         }
                     });


### PR DESCRIPTION
## Summary
- disable OpenAI request submit button during AJAX call and restore it after response to show spinner state

## Testing
- `composer validate`
- `composer test`
- `composer validate -d hugashop/crm`


------
https://chatgpt.com/codex/tasks/task_e_68b0a5e7d8808326a259b2e97628ba1d