### PR TITLE
feat: add meta autofill component

### DIFF
--- a/templates/admin/assets/js/common.js
+++ b/templates/admin/assets/js/common.js
@@ -4,7 +4,7 @@
  * Functions, actions
  * 
  * @author Andri Huga
- * @version 2.1
+ * @version 2.2
  * 
  */
 
@@ -72,6 +72,36 @@ export function generate_meta_description() {
 		replace(/(<([^>]+)>)/ig, ' ').
 		replace(/(\&nbsp;)/ig, ' ').
 		replace(/^\s+|\s+$/g, '').substr(0, 512);
+}
+
+export function autofillMeta(
+	name_selector = 'input[name="name"]',
+	meta_title_selector = 'input[name="meta_title"]',
+	url_selector = 'input[name="url"]'
+)
+{
+	let meta_title_touched = true;
+	let url_touched = true;
+
+	if ($(meta_title_selector).val() === generateMetaTitle() || $(meta_title_selector).val() === '') {
+		meta_title_touched = false;
+	}
+
+	if ($(url_selector).val() === generateUrl() || $(url_selector).val() === '') {
+		url_touched = false;
+	}
+
+	$(meta_title_selector).on('change', function () { meta_title_touched = true; });
+	$(url_selector).on('change', function () { url_touched = true; });
+
+	$(name_selector).on('keyup', function () {
+		if (!meta_title_touched) {
+		        $(meta_title_selector).val(generateMetaTitle());
+		}
+		if (!url_touched) {
+		        $(url_selector).val(generateUrl());
+		}
+	});
 }
 
 

--- a/templates/admin/html/content/page.tpl
+++ b/templates/admin/html/content/page.tpl
@@ -111,36 +111,16 @@
 
 	{include file='parts/tinymce_init.tpl'}
 
-	<script type="module">
-		import '{"js/fancybox/jquery.fancybox.min.js"|asset}';
-		import { generateMetaTitle, generateUrl, worldsCount } from '{"js/common.js"|asset}';
+       <script type="module">
+               import '{"js/fancybox/jquery.fancybox.min.js"|asset}';
+               import { worldsCount, autofillMeta } from '{"js/common.js"|asset}';
 
-		{literal}
-			$(function() {
-				worldsCount();
+               {literal}
+                       $(function() {
+                               worldsCount();
 
-				// Автозаполнение мета-тегов
-				let meta_title_touched = true;
-				let url_touched = true;
-
-				if ($('input[name="meta_title"]').val() == generateMetaTitle() ||
-					$('input[name="meta_title"]').val() == '')
-					meta_title_touched = false;
-
-				if ($('input[name="url"]').val() == generateUrl())
-					url_touched = false;
-
-				$('input[name="meta_title"]').change(function() { meta_title_touched = true; });
-				$('input[name="url"]').change(function() { url_touched = true; });
-				$('input[name="name"]').keyup(function() { set_meta(); });
-
-				function set_meta() {
-					if (!meta_title_touched)
-						$('input[name="meta_title"]').val(generateMetaTitle());
-					if (!url_touched)
-						$('input[name="url"]').val(generateUrl());
-				}
-			});
-		{/literal}
-	</script>
+                               autofillMeta();
+                       });
+               {/literal}
+       </script>
 {/block}

--- a/templates/admin/html/content/post.tpl
+++ b/templates/admin/html/content/post.tpl
@@ -117,40 +117,20 @@
 	{* Подключаем Tiny MCE *}
 	{include file='parts/tinymce_init.tpl'}
 
-	<script type="module">
-		import '{"js/jquery/datepicker/jquery.ui.datepicker-ru.js"|asset}';
-		import { generateMetaTitle, generateUrl, worldsCount } from '{"js/common.js"|asset}';
+       <script type="module">
+               import '{"js/jquery/datepicker/jquery.ui.datepicker-ru.js"|asset}';
+               import { worldsCount, autofillMeta } from '{"js/common.js"|asset}';
 
-		{literal}
-			$(function() {
-				worldsCount();
+               {literal}
+                       $(function() {
+                               worldsCount();
 
-				$('input[name="date"]').datepicker({
-					regional: 'ru'
-				});
+                               $('input[name="date"]').datepicker({
+                                       regional: 'ru'
+                               });
 
-				// Автозаполнение мета-тегов
-				let meta_title_touched = true;
-				let url_touched = true;
-
-				if ($('input[name="meta_title"]').val() == generateMetaTitle() ||
-					$('input[name="meta_title"]').val() == '')
-					meta_title_touched = false;
-
-				if ($('input[name="url"]').val() == generateUrl() || $('input[name="url"]').val() == '')
-					url_touched = false;
-
-				$('input[name="meta_title"]').change(function() { meta_title_touched = true; });
-				$('input[name="url"]').change(function() { url_touched = true; });
-				$('input[name="name"]').keyup(function() { set_meta(); });
-
-				function set_meta() {
-					if (!meta_title_touched)
-						$('input[name="meta_title"]').val(generateMetaTitle());
-					if (!url_touched)
-						$('input[name="url"]').val(generateUrl());
-				}
-			});
-		{/literal}
-	</script>
+                               autofillMeta();
+                       });
+               {/literal}
+       </script>
 {/block}


### PR DESCRIPTION
## Summary
- add reusable `autofillMeta` helper in admin `common.js` for meta title and URL generation
- integrate `autofillMeta` in post and page admin templates to auto-populate meta fields

## Testing
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68b22cfbbf4c8326a0d5d0d928b744af