### PR TITLE
feat: flexible addon menu placement

### DIFF
--- a/hugashop/crm/Addons/BookingShinomontag/settings.yaml
+++ b/hugashop/crm/Addons/BookingShinomontag/settings.yaml
@@ -11,4 +11,5 @@ settings_params:
       name: "Показывать в меню",
       options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }],
     }
-version: 1.2
+menu_section: crm
+version: 1.4

--- a/hugashop/crm/Addons/CarouselPromo/settings.yaml
+++ b/hugashop/crm/Addons/CarouselPromo/settings.yaml
@@ -11,4 +11,5 @@ settings_params:
       name: "Показывать в меню",
       options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }],
     }
-version: 1.2
+menu_section: content
+version: 1.4

--- a/hugashop/crm/Addons/Feedback/settings.yaml
+++ b/hugashop/crm/Addons/Feedback/settings.yaml
@@ -6,7 +6,8 @@ settings_params:
       name: "Показывать в меню",
       options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }],
     }
+menu_section: clients
 notifier:
   admin:
     - feedbackToAdmin: "Обратная связь"
-version: 1.2
+version: 1.4

--- a/hugashop/crm/Addons/ProductFilling/settings.yaml
+++ b/hugashop/crm/Addons/ProductFilling/settings.yaml
@@ -6,4 +6,5 @@ settings_params:
       name: "Показывать в меню",
       options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }],
     }
-version: 1.2
+menu_section: warehouse
+version: 1.4

--- a/hugashop/crm/Addons/ProductPriceRequest/settings.yaml
+++ b/hugashop/crm/Addons/ProductPriceRequest/settings.yaml
@@ -11,7 +11,8 @@ settings_params:
       name: "Показывать в меню",
       options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }],
     }
+menu_section: clients
 notifier:
   admin:
     - priceRequestToAdmin: "Запрос на скидку"
-version: 1.2
+version: 1.4

--- a/hugashop/crm/Addons/ProductStockManager/settings.yaml
+++ b/hugashop/crm/Addons/ProductStockManager/settings.yaml
@@ -6,4 +6,5 @@ settings_params:
       name: "Показывать в меню",
       options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }],
     }
-version: 1.1
+menu_section: warehouse
+version: 1.3

--- a/hugashop/crm/Addons/SeoPage/settings.yaml
+++ b/hugashop/crm/Addons/SeoPage/settings.yaml
@@ -11,4 +11,5 @@ settings_params:
       name: "Показывать в меню",
       options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }],
     }
-version: 1.7
+menu_section: content
+version: 1.9

--- a/hugashop/crm/Addons/TestScript/settings.yaml
+++ b/hugashop/crm/Addons/TestScript/settings.yaml
@@ -6,4 +6,5 @@ settings_params:
       name: "Показывать в меню",
       options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }],
     }
-version: 2.1
+menu_section: addon
+version: 2.3

--- a/hugashop/crm/Services/Addon.php
+++ b/hugashop/crm/Services/Addon.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.6
+ * @version 1.8
  *
  */
 
@@ -25,6 +25,20 @@ class Addon
     ];
 
     private static $place_cache = [];
+
+    /**
+     * Available admin menu sections
+     * @var array<int, string>
+     */
+    private static $menu_sections = [
+        'crm',
+        'warehouse',
+        'clients',
+        'content',
+        'finance',
+        'addon',
+        'settings'
+    ];
 
     /**
      * Update
@@ -54,7 +68,7 @@ class Addon
     /**
      * Get addons list for Admin menu
      */
-    public static function getMenuAddons()
+    public static function getMenuAddons(?string $section = null)
     {
         $menu_addons = [];
         foreach (self::getAddonsList() as $ext) {
@@ -62,7 +76,16 @@ class Addon
                 continue;
             }
             $settings = $Ext::getSettings();
-            if (!empty($settings->show_menu)) {
+            if (empty($settings->show_menu)) {
+                continue;
+            }
+            $place = $Ext::getConfig('menu_section') ?? 'addon';
+            if (!in_array($place, self::$menu_sections, true)) {
+                $place = 'addon';
+            }
+            if ($section === null) {
+                $menu_addons[$place][] = $ext;
+            } elseif ($section === $place) {
                 $menu_addons[] = $ext;
             }
         }

--- a/templates/admin/html/parts/side_menu_part.tpl
+++ b/templates/admin/html/parts/side_menu_part.tpl
@@ -48,6 +48,11 @@
                         <a href="{'LabelListAdmin'|linkLang}">Метки</a>
                     </li>
                 {/if}
+                {foreach $addons_menu.crm|default:[] as $ext_module}
+                    <li class="mini {if isset($addon) and $addon->module == $ext_module->module}active{/if}">
+                        <a href="{'AddonAdmin'|linkLang:[name => $ext_module->module]}">{$ext_module->name}</a>
+                    </li>
+                {/foreach}
             </ul>
         </li>
     {/if}
@@ -75,6 +80,11 @@
                         <a href="{'MoveListAdmin'|linkLang}">Поставки</a>
                     </li>
                 {/if}
+                {foreach $addons_menu.warehouse|default:[] as $ext_module}
+                    <li class="mini {if isset($addon) and $addon->module == $ext_module->module}active{/if}">
+                        <a href="{'AddonAdmin'|linkLang:[name => $ext_module->module]}">{$ext_module->name}</a>
+                    </li>
+                {/foreach}
             </ul>
         </li>
     {/if}
@@ -108,6 +118,11 @@
                         <a href="{'CouponListAdmin'|linkLang}">Купоны</a>
                     </li>
                 {/if}
+                {foreach $addons_menu.clients|default:[] as $ext_module}
+                    <li class="mini {if isset($addon) and $addon->module == $ext_module->module}active{/if}">
+                        <a href="{'AddonAdmin'|linkLang:[name => $ext_module->module]}">{$ext_module->name}</a>
+                    </li>
+                {/foreach}
             </ul>
         </li>
     {/if}
@@ -152,6 +167,11 @@
                         <a href="{'PageListAdmin'|linkLang}">Страницы</a>
                     </li>
                 {/if}
+                {foreach $addons_menu.content|default:[] as $ext_module}
+                    <li class="mini {if isset($addon) and $addon->module == $ext_module->module}active{/if}">
+                        <a href="{'AddonAdmin'|linkLang:[name => $ext_module->module]}">{$ext_module->name}</a>
+                    </li>
+                {/foreach}
             </ul>
         </li>
     {/if}
@@ -182,6 +202,11 @@
                         <a href="{'CurrencyAdmin'|linkLang}">Валюты</a>
                     </li>
                 {/if}
+                {foreach $addons_menu.finance|default:[] as $ext_module}
+                    <li class="mini {if isset($addon) and $addon->module == $ext_module->module}active{/if}">
+                        <a href="{'AddonAdmin'|linkLang:[name => $ext_module->module]}">{$ext_module->name}</a>
+                    </li>
+                {/foreach}
             </ul>
         </li>
     {/if}
@@ -200,7 +225,7 @@
                 <li class="mini {if $route == 'AddonListAdmin'}active{/if}">
                     <a href="{'AddonListAdmin'|linkLang}">Список модулей</a>
                 </li>
-                {foreach $addons_menu as $ext_module}
+                {foreach $addons_menu.addon|default:[] as $ext_module}
                     <li class="mini {if isset($addon) and $addon->module == $ext_module->module}active{/if}">
                         <a href="{'AddonAdmin'|linkLang:[name => $ext_module->module]}">{$ext_module->name}</a>
                     </li>
@@ -244,6 +269,11 @@
                         <a href="{'ThemeAdmin'|linkLang}">Тема</a>
                     </li>
                 {/if}
+                {foreach $addons_menu.settings|default:[] as $ext_module}
+                    <li class="mini {if isset($addon) and $addon->module == $ext_module->module}active{/if}">
+                        <a href="{'AddonAdmin'|linkLang:[name => $ext_module->module]}">{$ext_module->name}</a>
+                    </li>
+                {/foreach}
             </ul>
         </li>
     {/if}


### PR DESCRIPTION
## Summary
- remove menu_section from addon settings so addons pin themselves to a fixed admin menu section
- adjust Addon service to read menu section from static config

## Testing
- `php -l hugashop/crm/Services/Addon.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2610d1f788326a59a4f9f1979cc9b