### PR TITLE
feat: add product configurator addon

### DIFF
--- a/hugashop/crm/Addons/ProductConfigurator/Controller/ConfiguratorController.php
+++ b/hugashop/crm/Addons/ProductConfigurator/Controller/ConfiguratorController.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Addons\ProductConfigurator\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Secure;
+use HugaShop\Services\Request;
+use HugaShop\Services\Helper;
+use App\Controller\BaseAdminController;
+use HugaShop\Addons\BaseAddonTrait;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Addons\ProductConfigurator\Models\Configurator;
+use HugaShop\Addons\ProductConfigurator\Models\ConfiguratorStep;
+
+final class ConfiguratorController extends BaseAdminController
+{
+    use BaseAddonTrait;
+
+    #[Route('/ProductConfigurator/configurator', name: 'AddonProductConfiguratorNew', priority: 20)]
+    #[Route('/ProductConfigurator/configurator/{id}', name: 'AddonProductConfigurator', priority: 20)]
+    public function configurator(?int $id = null)
+    {
+        $configurator = new \stdClass();
+
+        if (Secure::checkCSRF()) {
+            if ($positions = Helper::getPositions()) {
+                foreach ($positions as $step_id => $position) {
+                    ConfiguratorStep::updateOne($step_id, ['position' => $position]);
+                }
+            }
+
+            if (!empty($config = Secure::getInputCheckEditAccess(Configurator::class, $id))) {
+                if (empty($config->id)) {
+                    $config = Design::setFlashMessage('add', Configurator::createOne($config));
+                } else {
+                    $config = Design::setFlashMessage('update', Configurator::updateOne($config->id, $config));
+                }
+                return $this->redirectToRoute('AddonProductConfigurator', ['id' => $config->id]);
+            }
+        }
+
+        if (!empty($id)) {
+            $configurator = Configurator::getOne($id);
+            if (empty($configurator->id)) {
+                return $this->redirectToRoute('AddonProductConfiguratorList');
+            }
+        }
+
+        Design::assign('configurator', $configurator);
+        Design::assign('steps', ConfiguratorStep::getList(['configurator_id' => $configurator->id ?? 0], order: 'position'));
+
+        return $this->fetchAddonResponse('configurator.tpl');
+    }
+}

--- a/hugashop/crm/Addons/ProductConfigurator/Controller/ConfiguratorListController.php
+++ b/hugashop/crm/Addons/ProductConfigurator/Controller/ConfiguratorListController.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Addons\ProductConfigurator\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Secure;
+use HugaShop\Services\Request;
+use App\Controller\BaseAdminController;
+use HugaShop\Addons\BaseAddonTrait;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Addons\ProductConfigurator\Models\Configurator;
+
+final class ConfiguratorListController extends BaseAdminController
+{
+    use BaseAddonTrait;
+
+    #[Route('/ProductConfigurator', name: 'AddonProductConfiguratorList', priority: 20)]
+    public function index()
+    {
+        if (Secure::checkCSRF()) {
+            $ids = Request::post('check');
+            if (is_array($ids)) {
+                switch (Request::post('action')) {
+                    case 'disable':
+                        Configurator::updateList($ids, ['enabled' => 0]);
+                        break;
+                    case 'enable':
+                        Configurator::updateList($ids, ['enabled' => 1]);
+                        break;
+                    case 'delete':
+                        foreach ($ids as $id) {
+                            Configurator::deleteOne($id);
+                        }
+                        break;
+                }
+            }
+        }
+
+        Design::assign('configurators', Configurator::getList(order: 'position'));
+        return $this->fetchAddonResponse('configurator_list.tpl');
+    }
+}

--- a/hugashop/crm/Addons/ProductConfigurator/Controller/FrontController.php
+++ b/hugashop/crm/Addons/ProductConfigurator/Controller/FrontController.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Addons\ProductConfigurator\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Secure;
+use HugaShop\Services\Request;
+use App\Controller\BaseFrontController;
+use HugaShop\Addons\BaseAddonTrait;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\HttpFoundation\Response;
+use HugaShop\Addons\ProductConfigurator\ProductConfigurator as ConfiguratorAddon;
+
+final class FrontController extends BaseFrontController
+{
+    use BaseAddonTrait;
+
+    #[Route('/configurator/{id}', name: 'AddonProductConfiguratorFront', priority: 1)]
+    public function index(int $id): Response
+    {
+        $configurator = ConfiguratorAddon::get_configurator($id);
+        if (empty($configurator)) {
+            return $this->redirectToRoute('home');
+        }
+
+        if (Secure::checkCSRF()) {
+            $selected = Request::post('option', []);
+            $total = 0;
+            $details = [];
+            foreach ($configurator->steps as $step) {
+                $opt_id = $selected[$step->id] ?? null;
+                if ($opt_id) {
+                    foreach ($step->options as $opt) {
+                        if ($opt->id == $opt_id) {
+                            $details[] = $step->name . ': ' . $opt->name;
+                            $total += $opt->price;
+                        }
+                    }
+                }
+            }
+            Design::assign('total', $total);
+            Design::assign('details', $details);
+            Design::assign('submitted', true);
+            Design::assign('name', Request::post('name'));
+            Design::assign('phone', Request::post('phone'));
+            Design::assign('email', Request::post('email'));
+        }
+
+        Design::assign('configurator', $configurator);
+        return $this->fetchAddonResponse('front.tpl');
+    }
+}

--- a/hugashop/crm/Addons/ProductConfigurator/Controller/StepController.php
+++ b/hugashop/crm/Addons/ProductConfigurator/Controller/StepController.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Addons\ProductConfigurator\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Secure;
+use HugaShop\Services\Request;
+use App\Controller\BaseAdminController;
+use HugaShop\Addons\BaseAddonTrait;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Addons\ProductConfigurator\Models\ConfiguratorStep;
+use HugaShop\Addons\ProductConfigurator\Models\ConfiguratorOption;
+
+final class StepController extends BaseAdminController
+{
+    use BaseAddonTrait;
+
+    #[Route('/ProductConfigurator/step/{configurator_id}', name: 'AddonProductConfiguratorStepNew', priority: 20)]
+    #[Route('/ProductConfigurator/step/{configurator_id}/{id}', name: 'AddonProductConfiguratorStep', priority: 20)]
+    public function step(int $configurator_id, ?int $id = null)
+    {
+        $step = new \stdClass();
+        $step->configurator_id = $configurator_id;
+
+        if (Secure::checkCSRF()) {
+            if (!empty($data = Secure::getInputCheckEditAccess(ConfiguratorStep::class, $id))) {
+                $data->configurator_id = $configurator_id;
+                if (empty($data->id)) {
+                    $data = Design::setFlashMessage('add', ConfiguratorStep::createOne($data));
+                } else {
+                    $data = Design::setFlashMessage('update', ConfiguratorStep::updateOne($data->id, $data));
+                }
+                $option_ids    = Request::post('option_id', []);
+                $option_names  = Request::post('option_name', []);
+                $option_prices = Request::post('option_price', []);
+                $keep_ids = [];
+                foreach ($option_names as $i => $name) {
+                    if (trim($name) === '') {
+                        continue;
+                    }
+                    $price = floatval($option_prices[$i] ?? 0);
+                    $opt_id = intval($option_ids[$i] ?? 0);
+                    $option = ConfiguratorOption::updateOrCreate(
+                        ['id' => $opt_id],
+                        [
+                            'step_id'  => $data->id,
+                            'name'     => $name,
+                            'price'    => $price,
+                            'position' => $i,
+                        ]
+                    );
+                    $keep_ids[] = $option->id;
+                }
+                ConfiguratorOption::where('step_id', $data->id)->whereNotIn('id', $keep_ids)->delete();
+                return $this->redirectToRoute('AddonProductConfiguratorStep', ['configurator_id' => $configurator_id, 'id' => $data->id]);
+            }
+        }
+
+        if (!empty($id)) {
+            $step = ConfiguratorStep::getOne($id);
+            if (empty($step->id) || $step->configurator_id != $configurator_id) {
+                return $this->redirectToRoute('AddonProductConfigurator', ['id' => $configurator_id]);
+            }
+        }
+
+        $options = ConfiguratorOption::getList(['step_id' => $step->id ?? 0], order: 'position');
+
+        Design::assign('step', $step);
+        Design::assign('options', $options);
+        Design::assign('configurator_id', $configurator_id);
+
+        return $this->fetchAddonResponse('step.tpl');
+    }
+}

--- a/hugashop/crm/Addons/ProductConfigurator/Models/Configurator.php
+++ b/hugashop/crm/Addons/ProductConfigurator/Models/Configurator.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Addons\ProductConfigurator\Models;
+
+use HugaShop\Addons\BaseAddonModel;
+
+final class Configurator extends BaseAddonModel
+{
+    protected static $table_fields = [
+        'id'          => ['type' => 'int',     'extra' => 'AUTO_INCREMENT'],
+        'name'        => ['type' => 'varchar', 'trans' => true, 'required' => true],
+        'description' => ['type' => 'text',    'trans' => true],
+        'position'    => ['type' => 'int',     'def' => 0],
+        'enabled'     => ['type' => 'tinyint', 'def' => 1],
+    ];
+}

--- a/hugashop/crm/Addons/ProductConfigurator/Models/ConfiguratorOption.php
+++ b/hugashop/crm/Addons/ProductConfigurator/Models/ConfiguratorOption.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Addons\ProductConfigurator\Models;
+
+use HugaShop\Addons\BaseAddonModel;
+
+final class ConfiguratorOption extends BaseAddonModel
+{
+    protected static $table_fields = [
+        'id'       => ['type' => 'int',     'extra' => 'AUTO_INCREMENT'],
+        'step_id'  => ['type' => 'int'],
+        'name'     => ['type' => 'varchar', 'trans' => true, 'required' => true],
+        'price'    => ['type' => 'decimal', 'length' => 14.2, 'def' => 0.00],
+        'position' => ['type' => 'int',     'def' => 0],
+    ];
+}

--- a/hugashop/crm/Addons/ProductConfigurator/Models/ConfiguratorStep.php
+++ b/hugashop/crm/Addons/ProductConfigurator/Models/ConfiguratorStep.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Addons\ProductConfigurator\Models;
+
+use HugaShop\Addons\BaseAddonModel;
+
+final class ConfiguratorStep extends BaseAddonModel
+{
+    protected static $table_fields = [
+        'id'              => ['type' => 'int',     'extra' => 'AUTO_INCREMENT'],
+        'configurator_id' => ['type' => 'int'],
+        'name'            => ['type' => 'varchar', 'trans' => true, 'required' => true],
+        'description'     => ['type' => 'text',    'trans' => true],
+        'image'           => ['type' => 'varchar'],
+        'position'        => ['type' => 'int',     'def' => 0],
+    ];
+}

--- a/hugashop/crm/Addons/ProductConfigurator/ProductConfigurator.php
+++ b/hugashop/crm/Addons/ProductConfigurator/ProductConfigurator.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ */
+
+namespace HugaShop\Addons\ProductConfigurator;
+
+use HugaShop\Addons\BaseAddon;
+use HugaShop\Addons\ProductConfigurator\Models\Configurator;
+use HugaShop\Addons\ProductConfigurator\Models\ConfiguratorStep;
+use HugaShop\Addons\ProductConfigurator\Models\ConfiguratorOption;
+
+final class ProductConfigurator extends BaseAddon
+{
+    /**
+     * Получаем конфигуратор с шагами и опциями
+     */
+    public static function get_configurator(int $id)
+    {
+        $configurator = Configurator::getOne(['id' => $id, 'enabled' => 1]);
+        if (empty($configurator->id)) {
+            return null;
+        }
+        $configurator->steps = ConfiguratorStep::getList(
+            ['configurator_id' => $configurator->id],
+            order: ['position', 'asc']
+        );
+        foreach ($configurator->steps as $step) {
+            $step->options = ConfiguratorOption::getList(
+                ['step_id' => $step->id],
+                order: ['position', 'asc']
+            );
+        }
+        return $configurator;
+    }
+}

--- a/hugashop/crm/Addons/ProductConfigurator/settings.yaml
+++ b/hugashop/crm/Addons/ProductConfigurator/settings.yaml
@@ -1,0 +1,5 @@
+name: "Подбор конфигурации продукта"
+description: "Пошаговый подбор комплектации и расчет стоимости"
+settings_params:
+  - { variable: enabled, name: "Включено", options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }] }
+version: 1.0

--- a/hugashop/crm/Addons/ProductConfigurator/templates/configurator.tpl
+++ b/hugashop/crm/Addons/ProductConfigurator/templates/configurator.tpl
@@ -1,0 +1,70 @@
+{extends 'wrapper/main.tpl'}
+{include 'addon/parts/menu_part.tpl'}
+
+{if $configurator->id}
+    {$meta_title = $configurator->name}
+{else}
+    {$meta_title = 'Новый конфигуратор'}
+{/if}
+
+{block name=content}
+    <form method="post">
+        <input type="hidden" name="id" value="{$configurator->id}" />
+        {getCSRFInput}
+
+        <div class="row gx-5">
+            <div class="col-12">
+                <div class="over_name">
+                    <div class="checkbox_line">
+                        <div class="form-check form-switch">
+                            <input type="hidden" name="enabled" value="0">
+                            <input class="form-check-input" name="enabled" value="1" type="checkbox" role="switch" id="enabled" {if $configurator->enabled}checked{/if} />
+                            <label class="form-check-label" for="enabled">Активен</label>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="name_row">
+                    <span class="col-form-label item_id">#{$configurator->id}</span>
+                    <input class="form-control form-control-lg" name="name" type="text" value="{$configurator->name}" />
+                </div>
+            </div>
+            <div class="col-12 layer">
+                <h2>Описание</h2>
+                <textarea name="description" class="form-control" rows="3">{$configurator->description}</textarea>
+            </div>
+            <div class="col-12 btn_row">
+                {include file="parts/button.tpl"}
+            </div>
+        </div>
+    </form>
+
+    {if $configurator->id}
+        <h2 class="mt-5">Шаги</h2>
+        <form method="post" class="list_form">
+            {getCSRFInput}
+            <div class="list sortable_on">
+                {foreach $steps as $step}
+                    <div class="list_row">
+                        <div class="move">
+                            <div class="move_zone"></div>
+                            <input type="hidden" name="positions[{$step->id}]" value="{$step->position}">
+                        </div>
+                        <div class="row col">
+                            <div class="col-12 col-sm-8">
+                                <a href="{'AddonProductConfiguratorStep'|link:[configurator_id=>$configurator->id,id=>$step->id]}">{$step->name}</a>
+                            </div>
+                            <div class="col-12 col-sm-4 text-end">
+                                <span class="badge text-bg-round">{$step->id}</span>
+                            </div>
+                        </div>
+                    </div>
+                {/foreach}
+            </div>
+            <div class="mt-3">
+                {include file="parts/button.tpl" label="Сохранить порядок"}
+                <a class="btn btn-outline-primary" href="{'AddonProductConfiguratorStepNew'|link:[configurator_id=>$configurator->id]}">Добавить шаг</a>
+            </div>
+        </form>
+    {/if}
+{/block}

--- a/hugashop/crm/Addons/ProductConfigurator/templates/configurator_list.tpl
+++ b/hugashop/crm/Addons/ProductConfigurator/templates/configurator_list.tpl
@@ -1,0 +1,73 @@
+{extends 'wrapper/main.tpl'}
+{include 'addon/parts/menu_part.tpl'}
+
+{$meta_title='Конфигураторы'}
+
+{block name=content}
+    <div class="header_top">
+        <h1>{$meta_title}</h1>
+        <a class="add" href="{'AddonProductConfiguratorNew'|link}">Добавить конфигуратор</a>
+    </div>
+
+    <div id="main_list">
+        {if $configurators}
+            <form method="post" class="list_form">
+                {getCSRFInput}
+                <div class="list sortable_on">
+                    {foreach $configurators as $conf}
+                        <div class="list_row {if !$conf->enabled}enabled_off{/if}">
+                            <div class="move">
+                                <div class="move_zone"></div>
+                                <input type="hidden" name="positions[{$conf->id}]" value="{$conf->position}">
+                            </div>
+                            <div class="checkbox">
+                                <input class="form-check-input" type="checkbox" name="check[]" value="{$conf->id}" />
+                            </div>
+                            <div class="row col">
+                                <div class="col-12 col-sm-8">
+                                    <a href="{'AddonProductConfigurator'|link:[id => $conf->id]}">{$conf->name}</a>
+                                </div>
+                                <div class="col-12 col-sm-4 text-end">
+                                    <span class="badge text-bg-round">{$conf->id}</span>
+                                </div>
+                            </div>
+                            <div class="icons">
+                                <i class="enable material-icons visibility" data-bs-toggle="tooltip" title="Активен"></i>
+                                <i class="delete material-icons" data-bs-toggle="tooltip" title="Удалить">cancel</i>
+                            </div>
+                        </div>
+                    {/foreach}
+                </div>
+
+                <div id="action">
+                    <span id="check_all" class="dash_link">Выбрать все</span>
+                    <span id="select">
+                        <select class="form-select" name="action">
+                            <option value="">Выбрать действие</option>
+                            <option value="enable">Сделать видимыми</option>
+                            <option value="disable">Сделать невидимыми</option>
+                            <option value="delete">Удалить</option>
+                        </select>
+                    </span>
+                    {include file="parts/button.tpl" label="Применить" extra_attrs='id=apply_action'}
+                </div>
+            </form>
+        {else}
+            Нет конфигураторов
+        {/if}
+    </div>
+{/block}
+
+{block name=body_script append}
+    <script type="module">
+        import { ajaxEntityUpdateIcon } from '{"js/common.js"|asset}';
+        {literal}
+        $(function(){
+            $("i.enable").click(function(){
+                ajaxEntityUpdateIcon($(this), 'ProductConfigurator', 'enabled', csrf);
+                return false;
+            });
+        });
+        {/literal}
+    </script>
+{/block}

--- a/hugashop/crm/Addons/ProductConfigurator/templates/front.tpl
+++ b/hugashop/crm/Addons/ProductConfigurator/templates/front.tpl
@@ -1,0 +1,58 @@
+{extends 'wrapper/main.tpl'}
+
+{$meta_title = $configurator->name}
+
+{block name=content}
+<form method="post" id="configurator_form">
+    {getCSRFInput}
+    <div id="configurator_steps">
+        {foreach $configurator->steps as $k=>$step}
+            <div class="config_step" data-step="{$step->id}" {if $k>0}style="display:none"{/if}>
+                <h3>{$step->name}</h3>
+                {if $step->image}<img src="{$step->image}" class="img-fluid mb-3" />{/if}
+                {foreach $step->options as $opt}
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="option[{$step->id}]" value="{$opt->id}" data-price="{$opt->price}" id="opt{$opt->id}" />
+                        <label class="form-check-label" for="opt{$opt->id}">{$opt->name} {if $opt->price>0}<span class="text-muted">+{$opt->price}</span>{/if}</label>
+                    </div>
+                {/foreach}
+                <button type="button" class="btn btn-primary mt-3 next_step">Далее</button>
+            </div>
+        {/foreach}
+        <div id="config_finish" style="display:none">
+            <h3>Контактные данные</h3>
+            <div class="mb-3"><input class="form-control" name="name" placeholder="Ваше имя" /></div>
+            <div class="mb-3"><input class="form-control" name="phone" placeholder="Телефон" /></div>
+            <div class="mb-3"><input class="form-control" name="email" placeholder="Email" /></div>
+            <p>Итого: <span id="total_price">0</span></p>
+            <button type="submit" class="btn btn-success">Отправить</button>
+        </div>
+    </div>
+</form>
+
+{if $submitted}
+    <div class="alert alert-success mt-3">Спасибо! Мы свяжемся с вами.</div>
+    <p>Итого: {$total}</p>
+{/if}
+{/block}
+
+{block name=body_script append}
+<script type="module">
+{literal}
+$(function(){
+    let total=0;
+    $('.next_step').click(function(){
+        let stepDiv=$(this).closest('.config_step');
+        let checked=stepDiv.find('input:checked');
+        if(!checked.length){return;}
+        total += parseFloat(checked.data('price')||0);
+        stepDiv.hide().next('.config_step').show();
+        if(!stepDiv.next('.config_step').length){
+            $('#config_finish').show();
+            $('#total_price').text(total.toFixed(2));
+        }
+    });
+});
+{/literal}
+</script>
+{/block}

--- a/hugashop/crm/Addons/ProductConfigurator/templates/step.tpl
+++ b/hugashop/crm/Addons/ProductConfigurator/templates/step.tpl
@@ -1,0 +1,63 @@
+{extends 'wrapper/main.tpl'}
+{include 'addon/parts/menu_part.tpl'}
+
+{if $step->id}
+    {$meta_title = $step->name}
+{else}
+    {$meta_title = 'Новый шаг'}
+{/if}
+
+{block name=content}
+    <form method="post">
+        <input type="hidden" name="id" value="{$step->id}" />
+        <input type="hidden" name="configurator_id" value="{$configurator_id}" />
+        {getCSRFInput}
+
+        <div class="row gx-5">
+            <div class="col-12">
+                <div class="name_row">
+                    <span class="col-form-label item_id">#{$step->id}</span>
+                    <input class="form-control form-control-lg" name="name" type="text" value="{$step->name}" />
+                </div>
+            </div>
+            <div class="col-12 layer">
+                <h2>Описание</h2>
+                <textarea name="description" class="form-control" rows="3">{$step->description}</textarea>
+            </div>
+            <div class="col-12 layer">
+                <h2>Картинка</h2>
+                <input class="form-control" name="image" type="text" value="{$step->image}" />
+            </div>
+            <div class="col-12 layer">
+                <h2>Опции</h2>
+                <div id="options">
+                    {foreach $options as $opt}
+                        <div class="row g-2 option_row mb-2">
+                            <input type="hidden" name="option_id[]" value="{$opt->id}">
+                            <div class="col-6"><input class="form-control" name="option_name[]" value="{$opt->name}"></div>
+                            <div class="col-4"><input class="form-control" name="option_price[]" value="{$opt->price}"></div>
+                            <div class="col-2"><button class="btn btn-outline-danger remove_option" type="button">&times;</button></div>
+                        </div>
+                    {/foreach}
+                </div>
+                <button type="button" class="btn btn-secondary mt-2" id="add_option">Добавить опцию</button>
+            </div>
+            <div class="col-12 btn_row">
+                {include file="parts/button.tpl"}
+            </div>
+        </div>
+    </form>
+{/block}
+
+{block name=body_script append}
+    <script type="module">
+        {literal}
+        $(function(){
+            $('#add_option').click(function(){
+                $('#options').append('<div class="row g-2 option_row mb-2"><input type="hidden" name="option_id[]" value=""><div class="col-6"><input class="form-control" name="option_name[]"></div><div class="col-4"><input class="form-control" name="option_price[]" value="0"></div><div class="col-2"><button class="btn btn-outline-danger remove_option" type="button">&times;</button></div></div>');
+            });
+            $(document).on('click','.remove_option',function(){ $(this).closest('.option_row').remove(); });
+        });
+        {/literal}
+    </script>
+{/block}


### PR DESCRIPTION
## Summary
- add ProductConfigurator addon with admin setup for configurators, steps and options
- implement frontend questionnaire with total price and contact form

## Testing
- `php -l hugashop/crm/Addons/ProductConfigurator/ProductConfigurator.php`
- `php -l hugashop/crm/Addons/ProductConfigurator/Models/Configurator.php`
- `php -l hugashop/crm/Addons/ProductConfigurator/Models/ConfiguratorStep.php`
- `php -l hugashop/crm/Addons/ProductConfigurator/Models/ConfiguratorOption.php`
- `php -l hugashop/crm/Addons/ProductConfigurator/Controller/ConfiguratorListController.php`
- `php -l hugashop/crm/Addons/ProductConfigurator/Controller/ConfiguratorController.php`
- `php -l hugashop/crm/Addons/ProductConfigurator/Controller/StepController.php`
- `php -l hugashop/crm/Addons/ProductConfigurator/Controller/FrontController.php`
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_e_68b78e695b148326b92fb924aa1d59e6