### PR TITLE
feat(seolinker): capture meta tags during crawl

### DIFF
--- a/hugashop/crm/Addons/SeoLinker/Models/SeoLinker.php
+++ b/hugashop/crm/Addons/SeoLinker/Models/SeoLinker.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.2
+ * @version 1.3
  *
  */
 
@@ -21,6 +21,9 @@ final class SeoLinker extends BaseAddonModel
         'out_internal'  => ['type' => 'int', 'def' => 0],
         'out_external'  => ['type' => 'int', 'def' => 0],
         'in_internal'   => ['type' => 'int', 'def' => 0],
+        'meta_title'    => ['type' => 'varchar'],
+        'meta_description' => ['type' => 'varchar'],
+        'h1'            => ['type' => 'varchar'],
         'scanned'       => ['type' => 'tinyint', 'def' => 0],
     ];
 }

--- a/hugashop/crm/Addons/SeoLinker/Services/CrawlerObserver.php
+++ b/hugashop/crm/Addons/SeoLinker/Services/CrawlerObserver.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.5
+ * @version 1.6
  *
  */
 
@@ -50,6 +50,18 @@ final class CrawlerObserver extends CrawlObserver
         @($dom->loadHTML($html));
         $xpath = new DOMXPath($dom);
         $nodes = $xpath->evaluate("//a[@href]");
+
+        $metaTitle = trim((string) $xpath->evaluate('string(//title)'));
+        $metaNode = $xpath->query("//meta[translate(@name,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')='description']");
+        $metaDescription = '';
+        if ($metaNode->length > 0) {
+            $metaDescription = trim((string) $metaNode->item(0)?->getAttribute('content'));
+        }
+        $h1Node = $xpath->query('//h1');
+        $h1 = '';
+        if ($h1Node->length > 0) {
+            $h1 = trim((string) $h1Node->item(0)?->textContent);
+        }
 
         foreach ($nodes as $node) {
             $href = trim($node->getAttribute('href'));
@@ -122,6 +134,9 @@ final class CrawlerObserver extends CrawlObserver
             'url' => $current,
             'out_internal' => $outInternal,
             'out_external' => $outExternal,
+            'meta_title' => $metaTitle,
+            'meta_description' => $metaDescription,
+            'h1' => $h1,
         ];
     }
 

--- a/hugashop/crm/Addons/SeoLinker/Services/ScanBatch.php
+++ b/hugashop/crm/Addons/SeoLinker/Services/ScanBatch.php
@@ -4,7 +4,7 @@
  * HugaShop - Sell anything
  *
  * @author Andri Huga
- * @version 1.8
+ * @version 1.9
  * 
  * SeoLinker addon
  * @link https://github.com/spatie/crawler
@@ -49,12 +49,15 @@ final class ScanBatch
         $pages = SeoLinker::where('scanned', 0)->limit(self::$limit)->get();
 
         foreach ($pages as $page) {
-            [$outInternal, $outExternal, $links] = self::crawlPage($page->url);
+            [$outInternal, $outExternal, $metaTitle, $metaDescription, $h1, $links] = self::crawlPage($page->url);
 
             SeoLinker::where('id', $page->id)->update([
                 'scanned' => 1,
                 'out_internal' => $outInternal,
                 'out_external' => $outExternal,
+                'meta_title' => $metaTitle,
+                'meta_description' => $metaDescription,
+                'h1' => $h1,
             ]);
 
             foreach ($links as $ln) {
@@ -121,11 +124,20 @@ final class ScanBatch
             ->setParseableMimeTypes(['text/html'])
             ->startCrawling($url);
 
-        $res = $observer->results[$url] ?? ['out_internal' => 0, 'out_external' => 0];
+        $res = $observer->results[$url] ?? [
+            'out_internal' => 0,
+            'out_external' => 0,
+            'meta_title' => '',
+            'meta_description' => '',
+            'h1' => '',
+        ];
 
         return [
             $res['out_internal'],
             $res['out_external'],
+            $res['meta_title'],
+            $res['meta_description'],
+            $res['h1'],
             $observer->links
         ];
     }

--- a/hugashop/crm/Addons/SeoLinker/templates/page.tpl
+++ b/hugashop/crm/Addons/SeoLinker/templates/page.tpl
@@ -8,6 +8,12 @@
         <h1>{$page->url}</h1>
     </div>
     <div id="main_list">
+        <div class="layer mb-4">
+            <h2>Метаданные</h2>
+            <div class="mb-2"><strong>Title:</strong> {$page->meta_title}</div>
+            <div class="mb-2"><strong>Description:</strong> {$page->meta_description}</div>
+            <div><strong>H1:</strong> {$page->h1}</div>
+        </div>
         <div class="row gx-5">
             <div class="col-lg-6 layer">
                 <h2>Исходящие ссылки</h2>


### PR DESCRIPTION
## Summary
- extend SeoLinker model to store meta title, description and h1
- parse and save page meta tags while crawling
- show collected meta data on page detail view

## Testing
- `php -l hugashop/crm/Addons/SeoLinker/Models/SeoLinker.php`
- `php -l hugashop/crm/Addons/SeoLinker/Services/CrawlerObserver.php`
- `php -l hugashop/crm/Addons/SeoLinker/Services/ScanBatch.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7933298cc8326bc87613583563df6