### PR TITLE
feat: add cron agent addon

### DIFF
--- a/hugashop/crm/Addons/CronAgent/Controller/CronAgentController.php
+++ b/hugashop/crm/Addons/CronAgent/Controller/CronAgentController.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ *
+ */
+
+namespace HugaShop\Addons\CronAgent\Controller;
+
+use HugaShop\Services\Design;
+use HugaShop\Services\Secure;
+use App\Controller\BaseAdminController;
+use HugaShop\Addons\BaseAddonTrait;
+use Symfony\Component\Routing\Attribute\Route;
+use HugaShop\Addons\CronAgent\Models\CronAgent as Agent;
+
+final class CronAgentController extends BaseAdminController
+{
+    use BaseAddonTrait;
+
+    /**
+     * Agents list
+     */
+    #[Route('/CronAgent', name: 'AddonCronAgent', priority: 20)]
+    public function index()
+    {
+        Design::assign('agents', Agent::getList());
+        Design::assign('addon', $this->getAddon());
+        return $this->fetchAddonResponse('agent_list.tpl');
+    }
+
+    /**
+     * Agent add/edit
+     * @param ?int $id
+     */
+    #[Route('/CronAgent/agent', name: 'AddonCronAgentNew', priority: 20)]
+    #[Route('/CronAgent/agent/{id}', name: 'AddonCronAgentAgent', priority: 20)]
+    public function agent(?int $id = null)
+    {
+        if (!empty($agent = Secure::getInputCheckEditAccess(Agent::class, $id))) {
+            if (empty($agent->id)) {
+                $agent = Design::setFlashMessage('add', Agent::createOne($agent));
+            } else {
+                $agent = Design::setFlashMessage('update', Agent::updateOne($agent->id, $agent));
+            }
+            return $this->redirectToRoute('AddonCronAgentAgent', ['id' => $agent->id]);
+        }
+
+        if (!empty($id)) {
+            $agent = Agent::getOne($id);
+            if (empty($agent->id)) {
+                return $this->redirectToRoute('AddonCronAgent');
+            }
+        }
+
+        Design::assign('addon', $this->getAddon());
+        Design::assign('agent', $agent);
+        return $this->fetchAddonResponse('agent.tpl');
+    }
+}

--- a/hugashop/crm/Addons/CronAgent/CronAgent.php
+++ b/hugashop/crm/Addons/CronAgent/CronAgent.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ *
+ */
+
+namespace HugaShop\Addons\CronAgent;
+
+use HugaShop\Addons\BaseAddon;
+
+final class CronAgent extends BaseAddon
+{
+}

--- a/hugashop/crm/Addons/CronAgent/EventListener/CronAgentListener.php
+++ b/hugashop/crm/Addons/CronAgent/EventListener/CronAgentListener.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ *
+ */
+
+namespace HugaShop\Addons\CronAgent\EventListener;
+
+use HugaShop\Addons\CronAgent\CronAgent;
+use HugaShop\Addons\CronAgent\Services\CronAgentService;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+
+final class CronAgentListener
+{
+    /**
+     * Run agents on site requests when cron is disabled
+     * @param RequestEvent $event
+     */
+    #[AsEventListener]
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        if (!CronAgent::isEnabled() || CronAgent::getSettings('use_cron')) {
+            return;
+        }
+
+        CronAgentService::run();
+    }
+}

--- a/hugashop/crm/Addons/CronAgent/Models/CronAgent.php
+++ b/hugashop/crm/Addons/CronAgent/Models/CronAgent.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ *
+ */
+
+namespace HugaShop\Addons\CronAgent\Models;
+
+use HugaShop\Addons\BaseAddonModel;
+
+final class CronAgent extends BaseAddonModel
+{
+    protected static $table_fields = [
+        'id'             => ['type' => 'int',      'extra' => 'AUTO_INCREMENT'],
+        'name'           => ['type' => 'varchar',  'required' => true],
+        'description'    => ['type' => 'text'],
+        'start_at'       => ['type' => 'datetime'],
+        'period_hours'   => ['type' => 'int',      'def' => 0],
+        'period_minutes' => ['type' => 'int',      'def' => 0],
+        'function'       => ['type' => 'varchar'],
+        'enabled'        => ['type' => 'tinyint',  'def' => 0],
+        'last_run_at'    => ['type' => 'datetime'],
+    ];
+}

--- a/hugashop/crm/Addons/CronAgent/Services/CronAgentService.php
+++ b/hugashop/crm/Addons/CronAgent/Services/CronAgentService.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ *
+ */
+
+namespace HugaShop\Addons\CronAgent\Services;
+
+use HugaShop\Addons\CronAgent\Models\CronAgent as Agent;
+
+final class CronAgentService
+{
+    /**
+     * Run active agents
+     */
+    public static function run(): void
+    {
+        $now = date('Y-m-d H:i:s');
+        $agents = Agent::getList(['enabled' => 1]);
+        foreach ($agents as $agent) {
+            if (self::isDue($agent, $now)) {
+                self::execute($agent);
+            }
+        }
+    }
+
+    /**
+     * Check is agent due
+     * @param object $agent
+     * @param string $now
+     */
+    private static function isDue(object $agent, string $now): bool
+    {
+        if (empty($agent->start_at)) {
+            return false;
+        }
+
+        if (empty($agent->last_run_at)) {
+            return $now >= $agent->start_at;
+        }
+
+        $next = date(
+            'Y-m-d H:i:s',
+            strtotime($agent->last_run_at . " +{$agent->period_hours} hours +{$agent->period_minutes} minutes")
+        );
+        return $now >= $next;
+    }
+
+    /**
+     * Execute agent function
+     * @param object $agent
+     */
+    private static function execute(object $agent): void
+    {
+        $callable = str_replace('()', '', (string) $agent->function);
+        if (str_contains($callable, '::')) {
+            [$class, $method] = explode('::', $callable);
+            if (class_exists($class) && method_exists($class, $method)) {
+                try {
+                    $class::$method();
+                } catch (\Throwable) {
+                    // Ignore errors
+                }
+            }
+        }
+
+        Agent::updateOne($agent->id, ['last_run_at' => date('Y-m-d H:i:s')]);
+    }
+}

--- a/hugashop/crm/Addons/CronAgent/settings.yaml
+++ b/hugashop/crm/Addons/CronAgent/settings.yaml
@@ -1,0 +1,6 @@
+name: "Cron агенты"
+description: "Выполнение произвольных методов по расписанию"
+settings_params:
+  - { variable: use_cron, name: "Запуск по cron", options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }] }
+menu_section: addon
+version: 1.0

--- a/hugashop/crm/Addons/CronAgent/templates/agent.tpl
+++ b/hugashop/crm/Addons/CronAgent/templates/agent.tpl
@@ -1,0 +1,71 @@
+{extends 'wrapper/main.tpl'}
+{include 'addon/parts/menu_part.tpl'}
+
+{if $agent->id}
+        {$meta_title = $agent->name}
+{else}
+        {$meta_title = 'Новый агент'}
+{/if}
+
+{block name=content}
+        <form method="post">
+                <input name="id" type="hidden" value="{$agent->id}" />
+                {getCSRFInput}
+
+                <div class="row gx-5">
+                        <div class="col-12">
+                                <div class="checkbox_line">
+                                        <div class="form-check form-switch">
+                                                <input type="hidden" name="enabled" value="0">
+                                                <input class="form-check-input" name="enabled" value="1" type="checkbox" role="switch" id="enabled" {if $agent->enabled}checked{/if} />
+                                                <label class="form-check-label" for="enabled">Активен</label>
+                                        </div>
+                                </div>
+                        </div>
+
+                        <div class="col-12">
+                                <div class="mb-3">
+                                        <label class="form-label">Название</label>
+                                        <input class="form-control form-control-lg" name="name" type="text" value="{$agent->name}" autocomplete="off" />
+                                </div>
+                        </div>
+
+                        <div class="col-12">
+                                <div class="mb-3">
+                                        <label class="form-label">Описание</label>
+                                        <textarea class="form-control" name="description">{$agent->description}</textarea>
+                                </div>
+                        </div>
+
+                        <div class="col-12 col-md-6">
+                                <div class="mb-3">
+                                        <label class="form-label">Дата запуска</label>
+                                        <input class="form-control" name="start_at" type="datetime-local" value="{$agent->start_at|date_format:'Y-m-d\\TH:i'}" />
+                                </div>
+                        </div>
+                        <div class="col-12 col-md-3">
+                                <div class="mb-3">
+                                        <label class="form-label">Часы</label>
+                                        <input class="form-control" name="period_hours" type="number" value="{$agent->period_hours}" min="0" />
+                                </div>
+                        </div>
+                        <div class="col-12 col-md-3">
+                                <div class="mb-3">
+                                        <label class="form-label">Минуты</label>
+                                        <input class="form-control" name="period_minutes" type="number" value="{$agent->period_minutes}" min="0" max="59" />
+                                </div>
+                        </div>
+
+                        <div class="col-12">
+                                <div class="mb-3">
+                                        <label class="form-label">Функция</label>
+                                        <input class="form-control" name="function" type="text" value="{$agent->function}" autocomplete="off" />
+                                </div>
+                        </div>
+
+                        <div class="col-12 btn_row">
+                                {include file="parts/button.tpl"}
+                        </div>
+                </div>
+        </form>
+{/block}

--- a/hugashop/crm/Addons/CronAgent/templates/agent_list.tpl
+++ b/hugashop/crm/Addons/CronAgent/templates/agent_list.tpl
@@ -1,0 +1,32 @@
+{extends 'wrapper/main.tpl'}
+{include 'addon/parts/menu_part.tpl'}
+
+{$meta_title='Cron агенты'}
+
+{block name=content}
+        <div class="header_top">
+                <h1>{$meta_title}</h1>
+                <a class="add" href={'AddonCronAgentNew'|link}>Добавить агента</a>
+        </div>
+
+        <div id="main_list">
+                {if $agents}
+                        <div class="list">
+                                {foreach $agents as $agent}
+                                        <div class="list_row {if !$agent->enabled}enabled_off{/if}">
+                                                <div class="row col">
+                                                        <div class="col-12 col-sm-8">
+                                                                <a href={'AddonCronAgentAgent'|link:[id => $agent->id]}>{$agent->name}</a>
+                                                        </div>
+                                                        <div class="col-12 col-sm-4 text-end">
+                                                                <span class="badge text-bg-round">{$agent->id}</span>
+                                                        </div>
+                                                </div>
+                                        </div>
+                                {/foreach}
+                        </div>
+                {else}
+                        Нет агентов
+                {/if}
+        </div>
+{/block}

--- a/src/Command/CronAgentsCommand.php
+++ b/src/Command/CronAgentsCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ *
+ */
+
+namespace App\Command;
+
+use HugaShop\Addons\CronAgent\CronAgent;
+use HugaShop\Addons\CronAgent\Services\CronAgentService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class CronAgentsCommand extends Command
+{
+    protected static $defaultName = 'cron:agents';
+    protected static $defaultDescription = 'Run Cron agents';
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!CronAgent::isEnabled() || !CronAgent::getSettings('use_cron')) {
+            $output->writeln('CronAgent addon disabled or not configured for cron.');
+            return Command::FAILURE;
+        }
+
+        CronAgentService::run();
+        $output->writeln('Agents executed.');
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
## Summary
- add CronAgent addon with configuration and admin UI
- schedule agent execution via service and request/cron triggers
- provide console command for cron-based runs

## Testing
- `php -l hugashop/crm/Addons/CronAgent/CronAgent.php`
- `php -l hugashop/crm/Addons/CronAgent/Models/CronAgent.php`
- `php -l hugashop/crm/Addons/CronAgent/Services/CronAgentService.php`
- `php -l hugashop/crm/Addons/CronAgent/EventListener/CronAgentListener.php`
- `php -l hugashop/crm/Addons/CronAgent/Controller/CronAgentController.php`
- `php -l src/Command/CronAgentsCommand.php`
- `composer dumpautoload`

------
https://chatgpt.com/codex/tasks/task_e_68ba65dfa86483269f823d46e61ddb67