### PR TITLE
Add Google Customer Reviews addon

### DIFF
--- a/hugashop/crm/Addons/GoogleCustomerReviews/GoogleCustomerReviews.php
+++ b/hugashop/crm/Addons/GoogleCustomerReviews/GoogleCustomerReviews.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * HugaShop - Sell anything
+ *
+ * @author Andri Huga
+ * @version 1.0
+ *
+ */
+
+namespace HugaShop\Addons\GoogleCustomerReviews;
+
+use DateTimeImmutable;
+use HugaShop\Addons\BaseAddon;
+use HugaShop\Services\Design;
+
+final class GoogleCustomerReviews extends BaseAddon
+{
+    /**
+     * Render Google Customer Reviews opt-in block for the front body.
+     */
+    public static function getFrontBodyTemplate(): ?string
+    {
+        $settings = self::getSettings();
+
+        if (empty($settings->enabled) || empty($settings->merchant_id) || empty($settings->delivery_country)) {
+            return null;
+        }
+
+        $settings->merchant_id = (int) $settings->merchant_id;
+        if ($settings->merchant_id <= 0) {
+            return null;
+        }
+
+        $settings->delivery_country = strtoupper((string) $settings->delivery_country);
+        $settings->delivery_days = isset($settings->delivery_days) ? max(0, (int) $settings->delivery_days) : 3;
+
+        $order = Design::getSmarty()->getTemplateVars('order');
+        $purchases = Design::getSmarty()->getTemplateVars('purchases');
+
+        $estimated_delivery_date = (new DateTimeImmutable())
+            ->modify(sprintf('+%d day', $settings->delivery_days))
+            ->format('Y-m-d');
+
+        if (!empty($order) && !empty($order->date)) {
+            $order_date = new DateTimeImmutable($order->date);
+            $estimated_delivery_date = $order_date
+                ->modify(sprintf('+%d day', $settings->delivery_days))
+                ->format('Y-m-d');
+        }
+
+        $gtins = [];
+        if (!empty($purchases) && is_iterable($purchases)) {
+            foreach ($purchases as $purchase) {
+                $gtin = null;
+                if (!empty($purchase->product?->sku)) {
+                    $gtin = $purchase->product->sku;
+                } elseif (!empty($purchase->sku)) {
+                    $gtin = $purchase->sku;
+                }
+
+                if (!empty($gtin)) {
+                    $gtins[] = (string) $gtin;
+                }
+            }
+        }
+
+        $payload = [
+            'merchant_id' => $settings->merchant_id,
+            'order_id' => !empty($order?->id) ? (string) $order->id : '',
+            'email' => !empty($order?->email) ? (string) $order->email : '',
+            'delivery_country' => $settings->delivery_country,
+            'estimated_delivery_date' => $estimated_delivery_date,
+        ];
+
+        if (!empty($gtins)) {
+            $payload['products'] = array_map(static function (string $gtin): array {
+                return ['gtin' => $gtin];
+            }, $gtins);
+        }
+
+        Design::assign('GoogleCustomerReviewsPayload', $payload);
+
+        return self::fetchTemplate('opt_in.tpl');
+    }
+}

--- a/hugashop/crm/Addons/GoogleCustomerReviews/settings.yaml
+++ b/hugashop/crm/Addons/GoogleCustomerReviews/settings.yaml
@@ -1,0 +1,12 @@
+name: "Google Отзывы клиентов"
+description: "Отправляет приглашение оставить отзыв в Google Customer Reviews после оформления заказа."
+settings_params:
+  - { variable: merchant_id, name: "Merchant ID" }
+  - { variable: delivery_country, name: "Страна доставки (ISO Alpha-2)" }
+  - { variable: delivery_days, name: "Срок доставки (дней)" }
+  - {
+      variable: enabled,
+      name: "Включено",
+      options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }],
+    }
+version: 1.0

--- a/hugashop/crm/Addons/GoogleCustomerReviews/templates/opt_in.tpl
+++ b/hugashop/crm/Addons/GoogleCustomerReviews/templates/opt_in.tpl
@@ -1,0 +1,15 @@
+{if $route == 'Order' and $message_success == 'added' and $order->email}
+    {assign var=payload value=$GoogleCustomerReviewsPayload}
+    {if $payload.order_id and $payload.email}
+        <script src="https://apis.google.com/js/platform.js?onload=renderOptIn" async defer></script>
+        <script>
+            window.renderOptIn = function() {
+                window.gapi.load('surveyoptin', function() {
+                    window.gapi.surveyoptin.render(
+                        {$payload|json_encode|raw}
+                    );
+                });
+            };
+        </script>
+    {/if}
+{/if}


### PR DESCRIPTION
## Summary
- add GoogleCustomerReviews addon that prepares the Google Customer Reviews opt-in payload from order context
- inject the opt-in script into the storefront body when an order is completed successfully
- provide addon settings for merchant identifier, delivery country, and delivery lead time

## Testing
- php -l hugashop/crm/Addons/GoogleCustomerReviews/GoogleCustomerReviews.php

------
https://chatgpt.com/codex/tasks/task_e_68d61a222a288326971e71b2d57fbbfc