### PR TITLE
Add timer visibility toggle for HelpOffer addon

### DIFF
--- a/hugashop/crm/Addons/HelpOffer/settings.yaml
+++ b/hugashop/crm/Addons/HelpOffer/settings.yaml
@@ -8,6 +8,11 @@ settings_params:
     }
   - { variable: timer, name: "Таймер показа (сек.)", placeholder: "30" }
   - {
+      variable: show_on_timer,
+      name: "Показывать по таймеру",
+      options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }],
+    }
+  - {
       variable: show_on_leave,
       name: "Показ при уходе",
       options: [{ name: "Нет", value: 0 }, { name: "Да", value: 1 }],
@@ -15,4 +20,4 @@ settings_params:
 notifier:
   admin:
     - offerToAdmin: "Заявка на помощь с выбором товара"
-version: 1.2
+version: 1.3

--- a/hugashop/crm/Addons/HelpOffer/templates/scripts.tpl
+++ b/hugashop/crm/Addons/HelpOffer/templates/scripts.tpl
@@ -3,6 +3,7 @@
 
     let offer_link = "{'AddonHelpOfferForm'|link}";
     let show_timer = {$HelpOffer->timer|default:0} * 1000;
+    let show_on_timer = {$HelpOffer->show_on_timer|default:0};
     let show_on_leave = {$HelpOffer->show_on_leave|default:0};
     let storage_key = 'help-offer';
     let offer_shown = false;
@@ -37,7 +38,7 @@
         if (localStorage.getItem(storage_key)) {
             return;
         }
-        if (show_timer > 0) {
+        if (show_on_timer && show_timer > 0) {
             setTimeout(openOffer, show_timer);
         }
         if (show_on_leave) {


### PR DESCRIPTION
## Summary
- add a configuration toggle to control whether HelpOffer displays on a timer
- update the front-end script to honor the new toggle when triggering the popup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690063b55cac8326a790912b4e91dc5a